### PR TITLE
Remove mt.exe requirement from setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -271,7 +271,11 @@ class BuildExtPythonnet(build_ext.build_ext):
     def _get_manifest(self, build_dir):
         if DEVTOOLS != "MsDev" and DEVTOOLS != "MsDev15":
             return
-        mt = self._find_msbuild_tool("mt.exe", use_windows_sdk=True)
+        try:
+            mt = self._find_msbuild_tool("mt.exe", use_windows_sdk=True)
+        except RuntimeError as e:
+            print(f'Cannot create manifest. Reason: {e}')
+            return
         manifest = os.path.abspath(os.path.join(build_dir, "app.manifest"))
         cmd = [mt, '-inputresource:"{0}"'.format(sys.executable),
                '-out:"{0}"'.format(manifest)]


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Removes mt.exe requirement from setup.

### Does this close any currently open issues?
No.

### Any other comments?
Create the manifest is not a feature that should force users to install Visual C++ for Python

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [x] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
