### PR TITLE
C# decimal to Python conversion

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.5.12
+current_version = 1.0.5.13
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<dev>\d+))?
 serialize = 
 	{major}.{minor}.{patch}.{release}{dev}

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: pythonnet
-  version: "1.0.5.12"
+  version: "1.0.5.13"
 
 build:
   skip: True  # [not win]

--- a/setup.py
+++ b/setup.py
@@ -485,7 +485,7 @@ if not os.path.exists(_get_interop_filename()):
 
 setup(
     name="pythonnet",
-    version="1.0.5.12",
+    version="1.0.5.13",
     description=".Net and Mono integration for Python",
     url='https://pythonnet.github.io/',
     license='MIT',

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -25,4 +25,4 @@ using System.Runtime.InteropServices;
 // Version Information. Keeping it simple. May need to revisit for Nuget
 // See: https://codingforsmarties.wordpress.com/2016/01/21/how-to-version-assemblies-destined-for-nuget/
 // AssemblyVersion can only be numeric
-[assembly: AssemblyVersion("1.0.5.12")]
+[assembly: AssemblyVersion("1.0.5.13")]

--- a/src/runtime/converter.cs
+++ b/src/runtime/converter.cs
@@ -28,7 +28,6 @@ namespace Python.Runtime
         private static Type flagsType;
         private static Type boolType;
         private static Type typeType;
-        private static IntPtr decimalCtor;
         private static IntPtr dateTimeCtor;
         private static IntPtr timeSpanCtor;
         private static IntPtr tzInfoCtor;
@@ -48,14 +47,8 @@ namespace Python.Runtime
             boolType = typeof(Boolean);
             typeType = typeof(Type);
 
-            IntPtr decimalMod = Runtime.PyImport_ImportModule("decimal");
-            if (decimalMod == null) throw new PythonException();
-
             IntPtr dateTimeMod = Runtime.PyImport_ImportModule("datetime");
             if (dateTimeMod == null) throw new PythonException();
-
-            decimalCtor = Runtime.PyObject_GetAttrString(decimalMod, "Decimal");
-            if (decimalCtor == null) throw new PythonException();
 
             dateTimeCtor = Runtime.PyObject_GetAttrString(dateTimeMod, "datetime");
             if (dateTimeCtor == null) throw new PythonException();
@@ -280,14 +273,9 @@ class GMT(tzinfo):
                     return Runtime.PyLong_FromUnsignedLongLong((ulong)value);
 
                 case TypeCode.Decimal:
-                    string d2s = ((decimal)value).ToString(nfi);
-                    IntPtr d2p = Runtime.PyString_FromString(d2s);
-                    IntPtr decimalArgs = Runtime.PyTuple_New(1);
-                    Runtime.PyTuple_SetItem(decimalArgs, 0, d2p);
-                    var returnDecimal = Runtime.PyObject_CallObject(decimalCtor, decimalArgs);
-                    // clean up
-                    Runtime.XDecref(decimalArgs);
-                    return returnDecimal;
+                    // C# decimal to python decimal has a big impact on performance
+                    // so we will use C# double and python float
+                    return Runtime.PyFloat_FromDouble(decimal.ToDouble((decimal) value));
 
                 case TypeCode.DateTime:
                     var datetime = (DateTime)value;

--- a/src/runtime/resources/clr.py
+++ b/src/runtime/resources/clr.py
@@ -2,7 +2,7 @@
 Code in this module gets loaded into the main clr module.
 """
 
-__version__ = "1.0.5.12"
+__version__ = "1.0.5.13"
 
 
 class clrproperty(object):


### PR DESCRIPTION


### What does this implement/fix? Explain your changes.
- C# decimal conversion will use C# double and python float due to the
big performance impact of converting C# decimal to python decimal.
- Advancing assembly version to 1.0.5.13
### Does this close any currently open issues?

Related to https://github.com/QuantConnect/Lean/issues/2825

