### PR TITLE
Performance improvements ClrObject - Dispose PyObj

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.5.13
+current_version = 1.0.5.14
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<dev>\d+))?
 serialize = 
 	{major}.{minor}.{patch}.{release}{dev}

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: pythonnet
-  version: "1.0.5.13"
+  version: "1.0.5.14"
 
 build:
   skip: True  # [not win]

--- a/setup.py
+++ b/setup.py
@@ -485,7 +485,7 @@ if not os.path.exists(_get_interop_filename()):
 
 setup(
     name="pythonnet",
-    version="1.0.5.13",
+    version="1.0.5.14",
     description=".Net and Mono integration for Python",
     url='https://pythonnet.github.io/',
     license='MIT',

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -25,4 +25,4 @@ using System.Runtime.InteropServices;
 // Version Information. Keeping it simple. May need to revisit for Nuget
 // See: https://codingforsmarties.wordpress.com/2016/01/21/how-to-version-assemblies-destined-for-nuget/
 // AssemblyVersion can only be numeric
-[assembly: AssemblyVersion("1.0.5.13")]
+[assembly: AssemblyVersion("1.0.5.14")]

--- a/src/clrmodule/ClrModule.cs
+++ b/src/clrmodule/ClrModule.cs
@@ -53,7 +53,7 @@ public class clrModule
         {
 #if USE_PYTHON_RUNTIME_VERSION
             // Has no effect until SNK works. Keep updated anyways.
-            Version = new Version("1.0.5.12"),
+            Version = new Version("1.0.5.14"),
 #endif
             CultureInfo = CultureInfo.InvariantCulture
         };

--- a/src/runtime/clrobject.cs
+++ b/src/runtime/clrobject.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.InteropServices;
 
 namespace Python.Runtime
@@ -29,9 +29,13 @@ namespace Python.Runtime
             gcHandle = gc;
             inst = ob;
 
-            // Fix the BaseException args (and __cause__ in case of Python 3)
-            // slot if wrapping a CLR exception
-            Exceptions.SetArgsAndCause(py);
+            // for performance before calling SetArgsAndCause() lets check if we are an exception
+            if (inst is Exception)
+            {
+                // Fix the BaseException args (and __cause__ in case of Python 3)
+                // slot if wrapping a CLR exception
+                Exceptions.SetArgsAndCause(py);
+            }
         }
 
 

--- a/src/runtime/pyobject.cs
+++ b/src/runtime/pyobject.cs
@@ -101,7 +101,7 @@ namespace Python.Runtime
             }
             return result;
         }
-        
+
         /// <summary>
         /// As Method
         /// </summary>
@@ -156,6 +156,23 @@ namespace Python.Runtime
             GC.SuppressFinalize(this);
         }
 
+        /// <summary>
+        /// Unsafe Dispose Method.
+        /// To be used when already owning the GIL lock. <see cref="Dispose()"/>
+        /// </summary>
+        public void UnsafeDispose()
+        {
+            if (!disposed)
+            {
+                if (!Runtime.IsFinalizing)
+                {
+                    Runtime.XDecref(obj);
+                    obj = IntPtr.Zero;
+                }
+                disposed = true;
+            }
+            GC.SuppressFinalize(this);
+        }
 
         /// <summary>
         /// GetPythonType Method

--- a/src/runtime/resources/clr.py
+++ b/src/runtime/resources/clr.py
@@ -2,7 +2,7 @@
 Code in this module gets loaded into the main clr module.
 """
 
-__version__ = "1.0.5.13"
+__version__ = "1.0.5.14"
 
 
 class clrproperty(object):


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
- Increasing minor version to 14
- Adding `UnsafeDispose()` for `PyObject` which does not require
acquiring/releasing the lock, for performance
- Adding check before calling `SetArgsAndCause` for the `ClrObject`, the
call only makes sense when we are an exception and causes an overhead.
3 seconds out of 43s.

Master Samplig:
![imagen](https://user-images.githubusercontent.com/18473240/51414708-1ed42a80-1b52-11e9-89a8-2fba17634ba1.png)

Algorithm:
```
from clr import AddReference
AddReference("System")
AddReference("QuantConnect.Algorithm")
AddReference("QuantConnect.Common")

from System import *
from QuantConnect import *
from QuantConnect.Algorithm import *
import numpy as np

from datetime import timedelta

class BasicTemplateAlgorithm(QCAlgorithm):

    def Initialize(self):
        self.SetStartDate(2015,1,1)
        self.SetEndDate(2018,1,1)
        self.SetCash(100000)

        self.symbols = [Symbol.Create(x, SecurityType.Equity, Market.USA)
                        for x in ["SPY", "GOOG", "AAPL", "FB", "AMZN"]]

        self.AddEquity("SPY", Resolution.Minute)
        self.UniverseSettings.Resolution = Resolution.Minute
        self.AddUniverse(self.CoarseSelectionFunction)

    def OnData(self, data):
        pass

    def CoarseSelectionFunction(self, coarse):
        return self.symbols
```

