### PR TITLE
Improve Indicator Performance Benchmark

### DIFF
--- a/src/runtime/interop.cs
+++ b/src/runtime/interop.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections;
-using System.Collections.Specialized;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Reflection;
 using System.Text;
@@ -88,8 +88,7 @@ namespace Python.Runtime
 
         public static int magic(IntPtr ob)
         {
-            if ((Runtime.PyObject_TypeCheck(ob, Exceptions.BaseException) ||
-                 (Runtime.PyType_Check(ob) && Runtime.PyType_IsSubtype(ob, Exceptions.BaseException))))
+            if (IsException(ob))
             {
                 return ExceptionOffset.ob_data;
             }
@@ -98,8 +97,7 @@ namespace Python.Runtime
 
         public static int DictOffset(IntPtr ob)
         {
-            if ((Runtime.PyObject_TypeCheck(ob, Exceptions.BaseException) ||
-                 (Runtime.PyType_Check(ob) && Runtime.PyType_IsSubtype(ob, Exceptions.BaseException))))
+            if (IsException(ob))
             {
                 return ExceptionOffset.ob_dict;
             }
@@ -108,8 +106,7 @@ namespace Python.Runtime
 
         public static int Size(IntPtr ob)
         {
-            if ((Runtime.PyObject_TypeCheck(ob, Exceptions.BaseException) ||
-                 (Runtime.PyType_Check(ob) && Runtime.PyType_IsSubtype(ob, Exceptions.BaseException))))
+            if (IsException(ob))
             {
                 return ExceptionOffset.Size();
             }
@@ -128,6 +125,21 @@ namespace Python.Runtime
         public static int ob_type;
         private static int ob_dict;
         private static int ob_data;
+        private static readonly Dictionary<IntPtr, bool> ExceptionTypeCache = new Dictionary<IntPtr, bool>();
+
+        private static bool IsException(IntPtr pyObject)
+        {
+            bool res;
+            var type = Runtime.PyObject_TYPE(pyObject);
+            if (!ExceptionTypeCache.TryGetValue(type, out res))
+            {
+                res = Runtime.PyObjectType_TypeCheck(type, Exceptions.BaseException)
+                    || Runtime.PyObjectType_TypeCheck(type, Runtime.PyTypeType)
+                    && Runtime.PyType_IsSubtype(pyObject, Exceptions.BaseException);
+                ExceptionTypeCache.Add(type, res);
+            }
+            return res;
+        }
     }
 
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]

--- a/src/runtime/propertyobject.cs
+++ b/src/runtime/propertyobject.cs
@@ -232,8 +232,13 @@ namespace Python.Runtime
             // so 'obj' is declared as typeof(object)
             var instance = Expression.Convert(obj, methodInfo.DeclaringType);
 
+            var parameters = methodInfo.GetParameters();
+            if (parameters.Length != 1)
+            {
+                return null;
+            }
             var value = Expression.Parameter(typeof(object));
-            var argument = Expression.Convert(value, methodInfo.GetParameters()[0].ParameterType);
+            var argument = Expression.Convert(value, parameters[0].ParameterType);
 
             var expressionCall = Expression.Call(instance, methodInfo, argument);
 

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -104,7 +104,7 @@ namespace Python.Runtime
     public class Runtime
     {
         // C# compiler copies constants to the assemblies that references this library.
-        // We needs to replace all public constants to static readonly fields to allow 
+        // We needs to replace all public constants to static readonly fields to allow
         // binary substitution of different Python.Runtime.dll builds in a target application.
 
         public static int UCS => _UCS;
@@ -130,7 +130,7 @@ namespace Python.Runtime
 #endif
 
         // C# compiler copies constants to the assemblies that references this library.
-        // We needs to replace all public constants to static readonly fields to allow 
+        // We needs to replace all public constants to static readonly fields to allow
         // binary substitution of different Python.Runtime.dll builds in a target application.
 
         public static string pyversion => _pyversion;
@@ -173,7 +173,7 @@ namespace Python.Runtime
 #endif
 
         // C# compiler copies constants to the assemblies that references this library.
-        // We needs to replace all public constants to static readonly fields to allow 
+        // We needs to replace all public constants to static readonly fields to allow
         // binary substitution of different Python.Runtime.dll builds in a target application.
 
         public static readonly string PythonDLL = _PythonDll;
@@ -1563,6 +1563,11 @@ namespace Python.Runtime
         {
             IntPtr t = PyObject_TYPE(ob);
             return (t == tp) || PyType_IsSubtype(t, tp);
+        }
+
+        internal static bool PyObjectType_TypeCheck(IntPtr type, IntPtr tp)
+        {
+            return (type == tp) || PyType_IsSubtype(type, tp);
         }
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]


### PR DESCRIPTION

### What does this implement/fix? Explain your changes.
- Adding new `interop` `type` cache holding a `bool`, true if its an `exception`.
- Adding a `setter` and `getter` cache for the `propertyobject`.

#### How Has This Been Tested?
Tested exeucting `QuantConnect` unit and regression tests and indicator performance benchmark:

[MASTER]
![imagen](https://user-images.githubusercontent.com/18473240/53108754-4f72ff80-3516-11e9-901b-de06264d822a.png)
[PR]
![imagen](https://user-images.githubusercontent.com/18473240/53109365-7c73e200-3517-11e9-8ba7-058858e05dd7.png)

[MASTER]
160.95 seconds at 5k data points per second. Processing total of 782,223 data points.
158.54 seconds at 5k data points per second. Processing total of 782,223 data points.
159.95 seconds at 5k data points per second. Processing total of 782,223 data points.
[PR]
132.27 seconds at 6k data points per second. Processing total of 782,223 data points.
130.07 seconds at 6k data points per second. Processing total of 782,223 data points.
129.88 seconds at 6k data points per second. Processing total of 782,223 data points.

[PR] has a 15-20% speed improvement.

**Note**
Testing showed no signficant impact on the `BasicTemplateAlgorithm` performance benchmark:
[python_benchmark_algo.txt](https://github.com/QuantConnect/pythonnet/files/2885668/python_benchmark_algo.txt)


### Does this close any currently open issues?
Related to https://github.com/QuantConnect/Lean/issues/2925

