### PR TITLE
Decimal Parsing Allows Numeric String in Exponential Notation and Version Bump

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.5.15
+current_version = 1.0.5.16
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<dev>\d+))?
 serialize = 
 	{major}.{minor}.{patch}.{release}{dev}

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: pythonnet
-  version: "1.0.5.15"
+  version: "1.0.5.16"
 
 build:
   skip: True  # [not win]

--- a/setup.py
+++ b/setup.py
@@ -485,7 +485,7 @@ if not os.path.exists(_get_interop_filename()):
 
 setup(
     name="pythonnet",
-    version="1.0.5.15",
+    version="1.0.5.16",
     description=".Net and Mono integration for Python",
     url='https://pythonnet.github.io/',
     license='MIT',

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -25,4 +25,4 @@ using System.Runtime.InteropServices;
 // Version Information. Keeping it simple. May need to revisit for Nuget
 // See: https://codingforsmarties.wordpress.com/2016/01/21/how-to-version-assemblies-destined-for-nuget/
 // AssemblyVersion can only be numeric
-[assembly: AssemblyVersion("1.0.5.15")]
+[assembly: AssemblyVersion("1.0.5.16")]

--- a/src/clrmodule/ClrModule.cs
+++ b/src/clrmodule/ClrModule.cs
@@ -53,7 +53,7 @@ public class clrModule
         {
 #if USE_PYTHON_RUNTIME_VERSION
             // Has no effect until SNK works. Keep updated anyways.
-            Version = new Version("1.0.5.15"),
+            Version = new Version("1.0.5.16"),
 #endif
             CultureInfo = CultureInfo.InvariantCulture
         };

--- a/src/runtime/converter.cs
+++ b/src/runtime/converter.cs
@@ -941,7 +941,7 @@ class GMT(tzinfo):
                     op = Runtime.PyObject_Str(value);
                     decimal m;
                     string sm = Runtime.GetManagedString(op);
-                    if (!Decimal.TryParse(sm, NumberStyles.Number, nfi, out m))
+                    if (!Decimal.TryParse(sm, NumberStyles.Number | NumberStyles.AllowExponent, nfi, out m))
                     {
                         goto type_error;
                     }

--- a/src/runtime/resources/clr.py
+++ b/src/runtime/resources/clr.py
@@ -2,7 +2,7 @@
 Code in this module gets loaded into the main clr module.
 """
 
-__version__ = "1.0.5.15"
+__version__ = "1.0.5.16"
 
 
 class clrproperty(object):


### PR DESCRIPTION
Decimal parsing allows numeric string in exponential notation in order to be able to convert float that maybe be represented in that notation.

Version bump to create nuget package with this fix and improvements from #24.