### PR TITLE
 Remove ExceptionTypeCache

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.5.16
+current_version = 1.0.5.17
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<dev>\d+))?
 serialize = 
 	{major}.{minor}.{patch}.{release}{dev}

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: pythonnet
-  version: "1.0.5.16"
+  version: "1.0.5.17"
 
 build:
   skip: True  # [not win]

--- a/setup.py
+++ b/setup.py
@@ -485,7 +485,7 @@ if not os.path.exists(_get_interop_filename()):
 
 setup(
     name="pythonnet",
-    version="1.0.5.16",
+    version="1.0.5.17",
     description=".Net and Mono integration for Python",
     url='https://pythonnet.github.io/',
     license='MIT',

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -25,4 +25,4 @@ using System.Runtime.InteropServices;
 // Version Information. Keeping it simple. May need to revisit for Nuget
 // See: https://codingforsmarties.wordpress.com/2016/01/21/how-to-version-assemblies-destined-for-nuget/
 // AssemblyVersion can only be numeric
-[assembly: AssemblyVersion("1.0.5.16")]
+[assembly: AssemblyVersion("1.0.5.17")]

--- a/src/clrmodule/ClrModule.cs
+++ b/src/clrmodule/ClrModule.cs
@@ -53,7 +53,7 @@ public class clrModule
         {
 #if USE_PYTHON_RUNTIME_VERSION
             // Has no effect until SNK works. Keep updated anyways.
-            Version = new Version("1.0.5.16"),
+            Version = new Version("1.0.5.17"),
 #endif
             CultureInfo = CultureInfo.InvariantCulture
         };

--- a/src/runtime/interop.cs
+++ b/src/runtime/interop.cs
@@ -125,20 +125,13 @@ namespace Python.Runtime
         public static int ob_type;
         private static int ob_dict;
         private static int ob_data;
-        private static readonly Dictionary<IntPtr, bool> ExceptionTypeCache = new Dictionary<IntPtr, bool>();
 
         private static bool IsException(IntPtr pyObject)
         {
-            bool res;
             var type = Runtime.PyObject_TYPE(pyObject);
-            if (!ExceptionTypeCache.TryGetValue(type, out res))
-            {
-                res = Runtime.PyObjectType_TypeCheck(type, Exceptions.BaseException)
-                    || Runtime.PyObjectType_TypeCheck(type, Runtime.PyTypeType)
-                    && Runtime.PyType_IsSubtype(pyObject, Exceptions.BaseException);
-                ExceptionTypeCache.Add(type, res);
-            }
-            return res;
+            return Runtime.PyObjectType_TypeCheck(type, Exceptions.BaseException)
+                || Runtime.PyObjectType_TypeCheck(type, Runtime.PyTypeType)
+                && Runtime.PyType_IsSubtype(pyObject, Exceptions.BaseException);
         }
     }
 

--- a/src/runtime/resources/clr.py
+++ b/src/runtime/resources/clr.py
@@ -2,7 +2,7 @@
 Code in this module gets loaded into the main clr module.
 """
 
-__version__ = "1.0.5.16"
+__version__ = "1.0.5.17"
 
 
 class clrproperty(object):


### PR DESCRIPTION
- Remove previously added `ExceptionTypeCache` which was causing issues and fix for issue
caused performance overhead.
- Bumping version to 1.0.5.17

Performance testing:
[MASTER C# IndicatorRibbonBenchmark] From PR https://github.com/QuantConnect/pythonnet/pull/24
132.27 seconds at 6k data points per second. Processing total of 782,223 data points.
130.07 seconds at 6k data points per second. Processing total of 782,223 data points.
129.88 seconds at 6k data points per second. Processing total of 782,223 data points.
[This PR C# IndicatorRibbonBenchmark]
127.63 seconds at 6k data points per second. Processing total of 782,223 data points.
127.83 seconds at 6k data points per second. Processing total of 782,223 data points.
127.44 seconds at 6k data points per second. Processing total of 782,223 data points.

**Results suggest the cache wasn't really giving a significant performance improvement.**