### PR TITLE
Fix memory leak finalizer

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.5.18
+current_version = 1.0.5.19
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<dev>\d+))?
 serialize = 
 	{major}.{minor}.{patch}.{release}{dev}

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: pythonnet
-  version: "1.0.5.18"
+  version: "1.0.5.19"
 
 build:
   skip: True  # [not win]

--- a/setup.py
+++ b/setup.py
@@ -485,7 +485,7 @@ if not os.path.exists(_get_interop_filename()):
 
 setup(
     name="pythonnet",
-    version="1.0.5.18",
+    version="1.0.5.19",
     description=".Net and Mono integration for Python",
     url='https://pythonnet.github.io/',
     license='MIT',

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -25,4 +25,4 @@ using System.Runtime.InteropServices;
 // Version Information. Keeping it simple. May need to revisit for Nuget
 // See: https://codingforsmarties.wordpress.com/2016/01/21/how-to-version-assemblies-destined-for-nuget/
 // AssemblyVersion can only be numeric
-[assembly: AssemblyVersion("1.0.5.18")]
+[assembly: AssemblyVersion("1.0.5.19")]

--- a/src/clrmodule/ClrModule.cs
+++ b/src/clrmodule/ClrModule.cs
@@ -53,7 +53,7 @@ public class clrModule
         {
 #if USE_PYTHON_RUNTIME_VERSION
             // Has no effect until SNK works. Keep updated anyways.
-            Version = new Version("1.0.5.18"),
+            Version = new Version("1.0.5.19"),
 #endif
             CultureInfo = CultureInfo.InvariantCulture
         };

--- a/src/runtime/resources/clr.py
+++ b/src/runtime/resources/clr.py
@@ -2,7 +2,7 @@
 Code in this module gets loaded into the main clr module.
 """
 
-__version__ = "1.0.5.18"
+__version__ = "1.0.5.19"
 
 
 class clrproperty(object):


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
- `finalizer` was leaking `_pendingArgs` (global memory) when the call
to `Py_AddPendingCall` was unsuccessful.
- Changing `lock` for `Monitor.TryEnter` at `AddPendingCollect()` so
threads don't block each other.
- Version bump 1.0.5.19