### PR TITLE
Improve Python.NET interop performance

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -39,6 +39,7 @@
 -   Sam Winstanley ([@swinstanley](https://github.com/swinstanley))
 -   Sean Freitag ([@cowboygneox](https://github.com/cowboygneox))
 -   Serge Weinstock ([@sweinst](https://github.com/sweinst))
+-   Victor Milovanov([@lostmsu](https://github.com/lostmsu))
 -   Ville M. Vainio ([@vivainio](https://github.com/vivainio))
 -   Virgil Dupras ([@hsoft](https://github.com/hsoft))
 -   Wenguang Yang ([@yagweb](https://github.com/yagweb))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 
 ### Changed
 -   PythonException included C# call stack
+-   improved performance of calls from Python to C#
 
 ### Fixed
 

--- a/src/runtime/classbase.cs
+++ b/src/runtime/classbase.cs
@@ -271,7 +271,7 @@ namespace Python.Runtime
         public static void tp_dealloc(IntPtr ob)
         {
             ManagedType self = GetManagedObject(ob);
-            IntPtr dict = Marshal.ReadIntPtr(ob, ObjectOffset.DictOffset(ob));
+            IntPtr dict = Marshal.ReadIntPtr(ob, ObjectOffset.TypeDictOffset(self.tpHandle));
             if (dict != IntPtr.Zero)
             {
                 Runtime.XDecref(dict);

--- a/src/runtime/classderived.cs
+++ b/src/runtime/classderived.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -870,7 +870,7 @@ namespace Python.Runtime
                         // the C# object is being destroyed which must mean there are no more
                         // references to the Python object as well so now we can dealloc the
                         // python object.
-                        IntPtr dict = Marshal.ReadIntPtr(self.pyHandle, ObjectOffset.DictOffset(self.pyHandle));
+                        IntPtr dict = Marshal.ReadIntPtr(self.pyHandle, ObjectOffset.TypeDictOffset(self.tpHandle));
                         if (dict != IntPtr.Zero)
                         {
                             Runtime.XDecref(dict);

--- a/src/runtime/clrobject.cs
+++ b/src/runtime/clrobject.cs
@@ -14,11 +14,11 @@ namespace Python.Runtime
             long flags = Util.ReadCLong(tp, TypeOffset.tp_flags);
             if ((flags & TypeFlags.Subclass) != 0)
             {
-                IntPtr dict = Marshal.ReadIntPtr(py, ObjectOffset.DictOffset(tp));
+                IntPtr dict = Marshal.ReadIntPtr(py, ObjectOffset.TypeDictOffset(tp));
                 if (dict == IntPtr.Zero)
                 {
                     dict = Runtime.PyDict_New();
-                    Marshal.WriteIntPtr(py, ObjectOffset.DictOffset(tp), dict);
+                    Marshal.WriteIntPtr(py, ObjectOffset.TypeDictOffset(tp), dict);
                 }
             }
 

--- a/src/runtime/managedtype.cs
+++ b/src/runtime/managedtype.cs
@@ -33,7 +33,7 @@ namespace Python.Runtime
                 {
                     IntPtr op = tp == ob
                         ? Marshal.ReadIntPtr(tp, TypeOffset.magic())
-                        : Marshal.ReadIntPtr(ob, ObjectOffset.magic(ob));
+                        : Marshal.ReadIntPtr(ob, ObjectOffset.magic(tp));
                     if (op == IntPtr.Zero)
                     {
                         return null;

--- a/src/runtime/moduleobject.cs
+++ b/src/runtime/moduleobject.cs
@@ -53,7 +53,7 @@ namespace Python.Runtime
             Runtime.XDecref(pyfilename);
             Runtime.XDecref(pydocstring);
 
-            Marshal.WriteIntPtr(pyHandle, ObjectOffset.DictOffset(pyHandle), dict);
+            Marshal.WriteIntPtr(pyHandle, ObjectOffset.TypeDictOffset(tpHandle), dict);
 
             InitializeModuleMembers();
         }

--- a/src/runtime/typemanager.cs
+++ b/src/runtime/typemanager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
@@ -79,7 +79,7 @@ namespace Python.Runtime
             // Set tp_basicsize to the size of our managed instance objects.
             Marshal.WriteIntPtr(type, TypeOffset.tp_basicsize, (IntPtr)ob_size);
 
-            var offset = (IntPtr)ObjectOffset.DictOffset(type);
+            var offset = (IntPtr)ObjectOffset.TypeDictOffset(type);
             Marshal.WriteIntPtr(type, TypeOffset.tp_dictoffset, offset);
 
             InitializeSlots(type, impl);
@@ -117,7 +117,6 @@ namespace Python.Runtime
 
             IntPtr base_ = IntPtr.Zero;
             int ob_size = ObjectOffset.Size(Runtime.PyTypeType);
-            int tp_dictoffset = ObjectOffset.DictOffset(Runtime.PyTypeType);
 
             // XXX Hack, use a different base class for System.Exception
             // Python 2.5+ allows new style class exceptions but they *must*
@@ -125,8 +124,9 @@ namespace Python.Runtime
             if (typeof(Exception).IsAssignableFrom(clrType))
             {
                 ob_size = ObjectOffset.Size(Exceptions.Exception);
-                tp_dictoffset = ObjectOffset.DictOffset(Exceptions.Exception);
             }
+
+            int tp_dictoffset = ob_size + ManagedDataOffsets.ob_dict;
 
             if (clrType == typeof(Exception))
             {


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

This improves the performance of Python -> C# calls by up to 50%.

#### Offset calculation for instance unwrapping
Commits 3344110 and  0d158f5 can actually be squashed into one change.
They addresses the following scenario:
1. A C# object `a` is created and filled with some data.
2. `a` is passed via Python.NET to Python. To do that Python.NET creates a wrapper object `w`, and stores reference to `a` in one of the its fields.
3. Python code later passes `w` back to C#, e.g. calls `SomeCSharpMethod(w)`.
4. Python.NET has to unwrap `w`, so it reads the reference to `a` from it.

Prior to this change in 4. Python.NET had to determine what kind of an object `a` is. If it is an exception, a different offset needed to be used. That check was very expensive (up to 4 calls into Python interpreter).

The change replaces that check with computing offset unconditionally from the object size it reads from the wrapper.

#### Replacing `Marshal.Read*/Marshal.Write*` methods in hot paths 12d1378
`Marshal` class methods provide safe way to read and write primitive values from unmanaged memory. Safety involves [two checks](https://github.com/dotnet/coreclr/blob/e083b2a4ab3045450005645dab8c009574a75d58/src/System.Private.CoreLib/shared/System/Runtime/InteropServices/Marshal.cs#L488):
1. An exception handler for `NullReferenceException` in case pointer is `null`: the contract, provided by `Marshal` class requires that to be converted to `AccessViolationException`.
2. Checking if the primitive is properly aligned in memory, and using a different procedure to access it otherwise.

Both are expensive, and not needed in Python.NET
1. Python.NET never handles exceptions from `Marshal`.
2. All allocations in Python are aligned, as it uses standard C allocator, that ensures alignment for large structures (e.g. PythonObject instances).

So a couple of methods are added to `Util` class to perform faster unmanaged memory access, and `Marshal` calls replaced with them in hot paths (mostly in `CLRObject` constructor).

### Does this close any currently open issues?

N/A

### Any other comments?

N/A

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change (N/A: no new features)
-   [ ] If an enhancement PR, please create docs and at best an example (N/A: no new features)
-   [x] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
