### PR TITLE
Fix initialization hang

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.5.23
+current_version = 1.0.5.24
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<dev>\d+))?
 serialize = 
 	{major}.{minor}.{patch}.{release}{dev}

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: pythonnet
-  version: "1.0.5.23"
+  version: "1.0.5.24"
 
 build:
   skip: True  # [not win]

--- a/setup.py
+++ b/setup.py
@@ -485,7 +485,7 @@ if not os.path.exists(_get_interop_filename()):
 
 setup(
     name="pythonnet",
-    version="1.0.5.23",
+    version="1.0.5.24",
     description=".Net and Mono integration for Python",
     url='https://pythonnet.github.io/',
     license='MIT',

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -25,4 +25,4 @@ using System.Runtime.InteropServices;
 // Version Information. Keeping it simple. May need to revisit for Nuget
 // See: https://codingforsmarties.wordpress.com/2016/01/21/how-to-version-assemblies-destined-for-nuget/
 // AssemblyVersion can only be numeric
-[assembly: AssemblyVersion("1.0.5.23")]
+[assembly: AssemblyVersion("1.0.5.24")]

--- a/src/clrmodule/ClrModule.cs
+++ b/src/clrmodule/ClrModule.cs
@@ -53,7 +53,7 @@ public class clrModule
         {
 #if USE_PYTHON_RUNTIME_VERSION
             // Has no effect until SNK works. Keep updated anyways.
-            Version = new Version("1.0.5.23"),
+            Version = new Version("1.0.5.24"),
 #endif
             CultureInfo = CultureInfo.InvariantCulture
         };

--- a/src/runtime/assemblymanager.cs
+++ b/src/runtime/assemblymanager.cs
@@ -344,6 +344,12 @@ namespace Python.Runtime
             // gather a list of all of the namespaces contributed to by
             // the assembly.
 
+            // skip this assembly, it causes 'GetTypes' call to hang
+            if (assembly.FullName.StartsWith("System.Windows.Forms"))
+            {
+                return;
+            }
+
             Type[] types = assembly.GetTypes();
             foreach (Type t in types)
             {

--- a/src/runtime/resources/clr.py
+++ b/src/runtime/resources/clr.py
@@ -2,7 +2,7 @@
 Code in this module gets loaded into the main clr module.
 """
 
-__version__ = "1.0.5.23"
+__version__ = "1.0.5.24"
 
 
 class clrproperty(object):


### PR DESCRIPTION
- Fix initialization hang. Calling `GetTypes()` in `AppDomain.AssemblyLoad` callback seems to be fragile and susceptible to internal deadlocks. `System.Windows.Forms` will be skipped since it was detected as the culprit of initialization hangs
     Some references: 
     1- https://github.com/dotnet/coreclr/issues/18580#issuecomment-399124386 
     2- https://social.msdn.microsoft.com/Forums/vstudio/en-US/29391803-7c5e-4324-9ae5-3d3792106fec/assemblygettypes-hangs-infinitely-on-net-40?forum=netfxbcl 
     3- https://support.postsharp.net/request/22051-postsharp-causes-assemblygettypes-to-hang-in

- Bump version to 1.0.5.24