### PR TITLE
Initialization hang fix

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.5.26
+current_version = 1.0.5.28
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<dev>\d+))?
 serialize = 
 	{major}.{minor}.{patch}.{release}{dev}

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: pythonnet
-  version: "1.0.5.26"
+  version: "1.0.5.28"
 
 build:
   skip: True  # [not win]

--- a/setup.py
+++ b/setup.py
@@ -485,7 +485,7 @@ if not os.path.exists(_get_interop_filename()):
 
 setup(
     name="pythonnet",
-    version="1.0.5.26",
+    version="1.0.5.28",
     description=".Net and Mono integration for Python",
     url='https://pythonnet.github.io/',
     license='MIT',

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -25,4 +25,4 @@ using System.Runtime.InteropServices;
 // Version Information. Keeping it simple. May need to revisit for Nuget
 // See: https://codingforsmarties.wordpress.com/2016/01/21/how-to-version-assemblies-destined-for-nuget/
 // AssemblyVersion can only be numeric
-[assembly: AssemblyVersion("1.0.5.26")]
+[assembly: AssemblyVersion("1.0.5.28")]

--- a/src/clrmodule/ClrModule.cs
+++ b/src/clrmodule/ClrModule.cs
@@ -53,7 +53,7 @@ public class clrModule
         {
 #if USE_PYTHON_RUNTIME_VERSION
             // Has no effect until SNK works. Keep updated anyways.
-            Version = new Version("1.0.5.26"),
+            Version = new Version("1.0.5.28"),
 #endif
             CultureInfo = CultureInfo.InvariantCulture
         };

--- a/src/runtime/classmanager.cs
+++ b/src/runtime/classmanager.cs
@@ -40,9 +40,8 @@ namespace Python.Runtime
         /// </summary>
         internal static ClassBase GetClass(Type type)
         {
-            ClassBase cb = null;
-            cache.TryGetValue(type, out cb);
-            if (cb != null)
+            ClassBase cb;
+            if (cache.TryGetValue(type, out cb))
             {
                 return cb;
             }

--- a/src/runtime/moduleobject.cs
+++ b/src/runtime/moduleobject.cs
@@ -67,9 +67,8 @@ namespace Python.Runtime
         /// </summary>
         public ManagedType GetAttribute(string name, bool guess)
         {
-            ManagedType cached = null;
-            cache.TryGetValue(name, out cached);
-            if (cached != null)
+            ManagedType cached;
+            if (cache.TryGetValue(name, out cached))
             {
                 return cached;
             }
@@ -77,16 +76,6 @@ namespace Python.Runtime
             ModuleObject m;
             ClassBase c;
             Type type;
-
-            //if (AssemblyManager.IsValidNamespace(name))
-            //{
-            //    IntPtr py_mod_name = Runtime.PyString_FromString(name);
-            //    IntPtr modules = Runtime.PyImport_GetModuleDict();
-            //    IntPtr module = Runtime.PyDict_GetItem(modules, py_mod_name);
-            //    if (module != IntPtr.Zero)
-            //        return (ManagedType)this;
-            //    return null;
-            //}
 
             string qname = _namespace == string.Empty
                 ? name
@@ -186,14 +175,9 @@ namespace Python.Runtime
         /// </summary>
         public void LoadNames()
         {
-            ManagedType m = null;
-            foreach (string name in AssemblyManager.GetNames(_namespace))
+            foreach (var name in AssemblyManager.GetNames(_namespace))
             {
-                cache.TryGetValue(name, out m);
-                if (m == null)
-                {
-                    ManagedType attr = GetAttribute(name, true);
-                }
+                var attr = GetAttribute(name, true);
             }
         }
 

--- a/src/runtime/resources/clr.py
+++ b/src/runtime/resources/clr.py
@@ -2,7 +2,7 @@
 Code in this module gets loaded into the main clr module.
 """
 
-__version__ = "1.0.5.26"
+__version__ = "1.0.5.28"
 
 
 class clrproperty(object):


### PR DESCRIPTION
- Perform assembly scan in separate worker tasks to
avoid initialization hang, due to calling `GetTypes` and for performance

Related to https://github.com/QuantConnect/LeanCloud/issues/505