### PR TITLE
Throw AttributeError in tp_setattro for dynamic classes

### DIFF
--- a/src/runtime/Types/DynamicClassObject.cs
+++ b/src/runtime/Types/DynamicClassObject.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Dynamic;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 
 using RuntimeBinder = Microsoft.CSharp.RuntimeBinder;
@@ -94,6 +92,7 @@ namespace Python.Runtime
                     // e.g hasattr uses this method to check if the attribute exists. If we throw anything other than AttributeError,
                     // hasattr will throw instead of catching and returning False.
                     Exceptions.SetError(Exceptions.AttributeError, exception.Message);
+                    return default;
                 }
             }
 

--- a/src/runtime/Types/DynamicClassObject.cs
+++ b/src/runtime/Types/DynamicClassObject.cs
@@ -120,7 +120,10 @@ namespace Python.Runtime
             // Catch C# exceptions and raise them as Python exceptions.
             catch (Exception exception)
             {
-                Exceptions.SetError(exception);
+                // tp_setattro should call PyObject_GenericSetAttr (which we already did)
+                // which must throw AttributeError on failure and return -1 (see https://docs.python.org/3/c-api/object.html#c.PyObject_GenericSetAttr)
+                Exceptions.SetError(Exceptions.AttributeError, exception.Message);
+                return -1;
             }
 
             return 0;


### PR DESCRIPTION
Python api documentation indicates it should throw AttributeError on failure and return -1. See https://docs.python.org/3/c-api/object.html#c.PyObject_GenericSetAttr

Following up #96 
