### PR TITLE
Support py list conversion to IReadOnlyList

### DIFF
--- a/src/embed_tests/TestConverter.cs
+++ b/src/embed_tests/TestConverter.cs
@@ -79,6 +79,21 @@ namespace Python.EmbeddingTest
         }
 
         [Test]
+        public void ReadOnlyList()
+        {
+            var array = new List<Type> { typeof(decimal), typeof(int) };
+            var py = array.ToPython();
+            object result;
+            var converted = Converter.ToManaged(py, typeof(IReadOnlyList<Type>), out result, false);
+
+            Assert.IsTrue(converted);
+            Assert.AreEqual(typeof(List<Type>), result.GetType());
+            Assert.AreEqual(2, ((IReadOnlyList<Type>)result).Count);
+            Assert.AreEqual(typeof(decimal), ((IReadOnlyList<Type>)result).ToList()[0]);
+            Assert.AreEqual(typeof(int), ((IReadOnlyList<Type>)result).ToList()[1]);
+        }
+
+        [Test]
         public void ConvertPyListToArray()
         {
             var array = new List<Type> { typeof(decimal), typeof(int) };

--- a/src/runtime/Converter.cs
+++ b/src/runtime/Converter.cs
@@ -421,7 +421,8 @@ class GMT(tzinfo):
                 if (typeDefinition == typeof(List<>)
                     || typeDefinition == typeof(IList<>)
                     || typeDefinition == typeof(IEnumerable<>)
-                    || typeDefinition == typeof(IReadOnlyCollection<>))
+                    || typeDefinition == typeof(IReadOnlyCollection<>)
+                    || typeDefinition == typeof(IReadOnlyList<>))
                 {
                     return ToList(value, obType, out result, setError);
                 }


### PR DESCRIPTION
Support py list conversion to IReadOnlyList, same as it's supported for IList, List, IReadOnlyCollection.

Related https://github.com/QuantConnect/quantconnect-stubs-generator/issues/61