### PR TITLE
C# enums to work as proper enums in Python

### DIFF
--- a/src/embed_tests/EnumTests.cs
+++ b/src/embed_tests/EnumTests.cs
@@ -1,0 +1,353 @@
+using System;
+using System.Collections.Generic;
+
+using NUnit.Framework;
+
+using Python.Runtime;
+
+namespace Python.EmbeddingTest
+{
+    public class EnumTests
+    {
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            PythonEngine.Initialize();
+        }
+
+        [OneTimeTearDown]
+        public void Dispose()
+        {
+            PythonEngine.Shutdown();
+        }
+
+        public enum Direction
+        {
+            Down = -2,
+            Flat = 0,
+            Up = 2,
+        }
+
+        [Test]
+        public void CSharpEnumsBehaveAsEnumsInPython()
+        {
+            using var _ = Py.GIL();
+            var module = PyModule.FromString("CSharpEnumsBehaveAsEnumsInPython", $@"
+from clr import AddReference
+AddReference(""Python.EmbeddingTest"")
+
+from Python.EmbeddingTest import *
+
+def enum_is_right_type(enum_value=EnumTests.Direction.Up):
+    return isinstance(enum_value, EnumTests.Direction)
+");
+
+            Assert.IsTrue(module.InvokeMethod("enum_is_right_type").As<bool>());
+
+            // Also test passing the enum value from C# to Python
+            using var pyEnumValue = Direction.Up.ToPython();
+            Assert.IsTrue(module.InvokeMethod("enum_is_right_type", pyEnumValue).As<bool>());
+        }
+
+        private PyModule GetTestOperatorsModule(string @operator, Direction operand1, double operand2)
+        {
+            var operand1Str = $"{nameof(EnumTests)}.{nameof(Direction)}.{operand1}";
+            return PyModule.FromString("GetTestOperatorsModule", $@"
+from clr import AddReference
+AddReference(""Python.EmbeddingTest"")
+
+from Python.EmbeddingTest import *
+
+def operation1():
+    return {operand1Str} {@operator} {operand2}
+
+def operation2():
+    return {operand2} {@operator} {operand1Str}
+");
+        }
+
+        [TestCase(" *", Direction.Down, 2, -4)]
+        [TestCase("/", Direction.Down, 2, -1)]
+        [TestCase("+", Direction.Down, 2, 0)]
+        [TestCase("-", Direction.Down, 2, -4)]
+        [TestCase("*", Direction.Flat, 2, 0)]
+        [TestCase("/", Direction.Flat, 2, 0)]
+        [TestCase("+", Direction.Flat, 2, 2)]
+        [TestCase("-", Direction.Flat, 2, -2)]
+        [TestCase("*", Direction.Up, 2, 4)]
+        [TestCase("/", Direction.Up, 2, 1)]
+        [TestCase("+", Direction.Up, 2, 4)]
+        [TestCase("-", Direction.Up, 2, 0)]
+        public void ArithmeticOperatorsWorkWithoutExplicitCast(string @operator, Direction operand1, double operand2, double expectedResult)
+        {
+            using var _ = Py.GIL();
+            var module = GetTestOperatorsModule(@operator, operand1, operand2);
+
+            Assert.AreEqual(expectedResult, module.InvokeMethod("operation1").As<double>());
+            Assert.AreEqual(expectedResult, module.InvokeMethod("operation2").As<double>());
+        }
+
+        [TestCase("==", Direction.Down, -2, true)]
+        [TestCase("==", Direction.Down, 0, false)]
+        [TestCase("==", Direction.Down, 2, false)]
+        [TestCase("==", Direction.Flat, -2, false)]
+        [TestCase("==", Direction.Flat, 0, true)]
+        [TestCase("==", Direction.Flat, 2, false)]
+        [TestCase("==", Direction.Up, -2, false)]
+        [TestCase("==", Direction.Up, 0, false)]
+        [TestCase("==", Direction.Up, 2, true)]
+        [TestCase("!=", Direction.Down, -2, false)]
+        [TestCase("!=", Direction.Down, 0, true)]
+        [TestCase("!=", Direction.Down, 2, true)]
+        [TestCase("!=", Direction.Flat, -2, true)]
+        [TestCase("!=", Direction.Flat, 0, false)]
+        [TestCase("!=", Direction.Flat, 2, true)]
+        [TestCase("!=", Direction.Up, -2, true)]
+        [TestCase("!=", Direction.Up, 0, true)]
+        [TestCase("!=", Direction.Up, 2, false)]
+        [TestCase("<", Direction.Down, -3, false)]
+        [TestCase("<", Direction.Down, -2, false)]
+        [TestCase("<", Direction.Down, 0, true)]
+        [TestCase("<", Direction.Down, 2, true)]
+        [TestCase("<", Direction.Flat, -2, false)]
+        [TestCase("<", Direction.Flat, 0, false)]
+        [TestCase("<", Direction.Flat, 2, true)]
+        [TestCase("<", Direction.Up, -2, false)]
+        [TestCase("<", Direction.Up, 0, false)]
+        [TestCase("<", Direction.Up, 2, false)]
+        [TestCase("<", Direction.Up, 3, true)]
+        [TestCase("<=", Direction.Down, -3, false)]
+        [TestCase("<=", Direction.Down, -2, true)]
+        [TestCase("<=", Direction.Down, 0, true)]
+        [TestCase("<=", Direction.Down, 2, true)]
+        [TestCase("<=", Direction.Flat, -2, false)]
+        [TestCase("<=", Direction.Flat, 0, true)]
+        [TestCase("<=", Direction.Flat, 2, true)]
+        [TestCase("<=", Direction.Up, -2, false)]
+        [TestCase("<=", Direction.Up, 0, false)]
+        [TestCase("<=", Direction.Up, 2, true)]
+        [TestCase("<=", Direction.Up, 3, true)]
+        [TestCase(">", Direction.Down, -3, true)]
+        [TestCase(">", Direction.Down, -2, false)]
+        [TestCase(">", Direction.Down, 0, false)]
+        [TestCase(">", Direction.Down, 2, false)]
+        [TestCase(">", Direction.Flat, -2, true)]
+        [TestCase(">", Direction.Flat, 0, false)]
+        [TestCase(">", Direction.Flat, 2, false)]
+        [TestCase(">", Direction.Up, -2, true)]
+        [TestCase(">", Direction.Up, 0, true)]
+        [TestCase(">", Direction.Up, 2, false)]
+        [TestCase(">", Direction.Up, 3, false)]
+        [TestCase(">=", Direction.Down, -3, true)]
+        [TestCase(">=", Direction.Down, -2, true)]
+        [TestCase(">=", Direction.Down, 0, false)]
+        [TestCase(">=", Direction.Down, 2, false)]
+        [TestCase(">=", Direction.Flat, -2, true)]
+        [TestCase(">=", Direction.Flat, 0, true)]
+        [TestCase(">=", Direction.Flat, 2, false)]
+        [TestCase(">=", Direction.Up, -2, true)]
+        [TestCase(">=", Direction.Up, 0, true)]
+        [TestCase(">=", Direction.Up, 2, true)]
+        [TestCase(">=", Direction.Up, 3, false)]
+        public void IntComparisonOperatorsWorkWithoutExplicitCast(string @operator, Direction operand1, int operand2, bool expectedResult)
+        {
+            using var _ = Py.GIL();
+            var module = GetTestOperatorsModule(@operator, operand1, operand2);
+
+            Assert.AreEqual(expectedResult, module.InvokeMethod("operation1").As<bool>());
+
+            var invertedOperationExpectedResult = (@operator.StartsWith('<') || @operator.StartsWith('>')) && Convert.ToInt64(operand1) != operand2
+                ? !expectedResult
+                : expectedResult;
+            Assert.AreEqual(invertedOperationExpectedResult, module.InvokeMethod("operation2").As<bool>());
+        }
+
+        [TestCase("==", Direction.Down, -2.0, true)]
+        [TestCase("==", Direction.Down, -2.00001, false)]
+        [TestCase("==", Direction.Down, -1.99999, false)]
+        [TestCase("==", Direction.Down, 0.0, false)]
+        [TestCase("==", Direction.Down, 2.0, false)]
+        [TestCase("==", Direction.Flat, -2.0, false)]
+        [TestCase("==", Direction.Flat, 0.0, true)]
+        [TestCase("==", Direction.Flat, 0.00001, false)]
+        [TestCase("==", Direction.Flat, -0.00001, false)]
+        [TestCase("==", Direction.Flat, 2.0, false)]
+        [TestCase("==", Direction.Up, -2.0, false)]
+        [TestCase("==", Direction.Up, 0.0, false)]
+        [TestCase("==", Direction.Up, 2.0, true)]
+        [TestCase("==", Direction.Up, 2.00001, false)]
+        [TestCase("==", Direction.Up, 1.99999, false)]
+        [TestCase("!=", Direction.Down, -2.0, false)]
+        [TestCase("!=", Direction.Down, -2.00001, true)]
+        [TestCase("!=", Direction.Down, -1.99999, true)]
+        [TestCase("!=", Direction.Down, 0.0, true)]
+        [TestCase("!=", Direction.Down, 2.0, true)]
+        [TestCase("!=", Direction.Flat, -2.0, true)]
+        [TestCase("!=", Direction.Flat, 0.0, false)]
+        [TestCase("!=", Direction.Flat, 0.00001, true)]
+        [TestCase("!=", Direction.Flat, -0.00001, true)]
+        [TestCase("!=", Direction.Flat, 2.0, true)]
+        [TestCase("!=", Direction.Up, -2.0, true)]
+        [TestCase("!=", Direction.Up, 0.0, true)]
+        [TestCase("!=", Direction.Up, 2.0, false)]
+        [TestCase("!=", Direction.Up, 2.00001, true)]
+        [TestCase("!=", Direction.Up, 1.99999, true)]
+        [TestCase("<", Direction.Down, -3.0, false)]
+        [TestCase("<", Direction.Down, -2.00001, false)]
+        [TestCase("<", Direction.Down, -2.0, false)]
+        [TestCase("<", Direction.Down, -1.99999, true)]
+        [TestCase("<", Direction.Down, 0.0, true)]
+        [TestCase("<", Direction.Down, 2.0, true)]
+        [TestCase("<", Direction.Flat, -2.0, false)]
+        [TestCase("<", Direction.Flat, -0.00001, false)]
+        [TestCase("<", Direction.Flat, 0.0, false)]
+        [TestCase("<", Direction.Flat, 0.00001, true)]
+        [TestCase("<", Direction.Flat, 2.0, true)]
+        [TestCase("<", Direction.Up, -2.0, false)]
+        [TestCase("<", Direction.Up, 0.0, false)]
+        [TestCase("<", Direction.Up, 1.99999, false)]
+        [TestCase("<", Direction.Up, 2.0, false)]
+        [TestCase("<", Direction.Up, 2.00001, true)]
+        [TestCase("<", Direction.Up, 3.0, true)]
+        [TestCase("<=", Direction.Down, -3.0, false)]
+        [TestCase("<=", Direction.Down, -2.00001, false)]
+        [TestCase("<=", Direction.Down, -2.0, true)]
+        [TestCase("<=", Direction.Down, -1.99999, true)]
+        [TestCase("<=", Direction.Down, 0.0, true)]
+        [TestCase("<=", Direction.Down, 2.0, true)]
+        [TestCase("<=", Direction.Flat, -2.0, false)]
+        [TestCase("<=", Direction.Flat, -0.00001, false)]
+        [TestCase("<=", Direction.Flat, 0.0, true)]
+        [TestCase("<=", Direction.Flat, 0.00001, true)]
+        [TestCase("<=", Direction.Flat, 2.0, true)]
+        [TestCase("<=", Direction.Up, -2.0, false)]
+        [TestCase("<=", Direction.Up, 0.0, false)]
+        [TestCase("<=", Direction.Up, 1.99999, false)]
+        [TestCase("<=", Direction.Up, 2.0, true)]
+        [TestCase("<=", Direction.Up, 2.00001, true)]
+        [TestCase("<=", Direction.Up, 3.0, true)]
+        [TestCase(">", Direction.Down, -3.0, true)]
+        [TestCase(">", Direction.Down, -2.00001, true)]
+        [TestCase(">", Direction.Down, -2.0, false)]
+        [TestCase(">", Direction.Down, -1.99999, false)]
+        [TestCase(">", Direction.Down, 0.0, false)]
+        [TestCase(">", Direction.Down, 2.0, false)]
+        [TestCase(">", Direction.Flat, -2.0, true)]
+        [TestCase(">", Direction.Flat, -0.00001, true)]
+        [TestCase(">", Direction.Flat, 0.0, false)]
+        [TestCase(">", Direction.Flat, 0.00001, false)]
+        [TestCase(">", Direction.Flat, 2.0, false)]
+        [TestCase(">", Direction.Up, -2.0, true)]
+        [TestCase(">", Direction.Up, 0.0, true)]
+        [TestCase(">", Direction.Up, 1.99999, true)]
+        [TestCase(">", Direction.Up, 2.0, false)]
+        [TestCase(">", Direction.Up, 2.00001, false)]
+        [TestCase(">", Direction.Up, 3.0, false)]
+        [TestCase(">=", Direction.Down, -3.0, true)]
+        [TestCase(">=", Direction.Down, -2.00001, true)]
+        [TestCase(">=", Direction.Down, -2.0, true)]
+        [TestCase(">=", Direction.Down, -1.99999, false)]
+        [TestCase(">=", Direction.Down, 0.0, false)]
+        [TestCase(">=", Direction.Down, 2.0, false)]
+        [TestCase(">=", Direction.Flat, -2.0, true)]
+        [TestCase(">=", Direction.Flat, -0.00001, true)]
+        [TestCase(">=", Direction.Flat, 0.0, true)]
+        [TestCase(">=", Direction.Flat, 0.00001, false)]
+        [TestCase(">=", Direction.Flat, 2.0, false)]
+        [TestCase(">=", Direction.Up, -2.0, true)]
+        [TestCase(">=", Direction.Up, 0.0, true)]
+        [TestCase(">=", Direction.Up, 1.99999, true)]
+        [TestCase(">=", Direction.Up, 2.0, true)]
+        [TestCase(">=", Direction.Up, 2.00001, false)]
+        [TestCase(">=", Direction.Up, 3.0, false)]
+        public void FloatComparisonOperatorsWorkWithoutExplicitCast(string @operator, Direction operand1, double operand2, bool expectedResult)
+        {
+            using var _ = Py.GIL();
+            var module = GetTestOperatorsModule(@operator, operand1, operand2);
+
+            Assert.AreEqual(expectedResult, module.InvokeMethod("operation1").As<bool>());
+
+            var invertedOperationExpectedResult = (@operator.StartsWith('<') || @operator.StartsWith('>')) && Convert.ToInt64(operand1) != operand2
+                ? !expectedResult
+                : expectedResult;
+            Assert.AreEqual(invertedOperationExpectedResult, module.InvokeMethod("operation2").As<bool>());
+        }
+
+        public static IEnumerable<TestCaseData> SameEnumTypeComparisonOperatorsTestCases
+        {
+            get
+            {
+                var operators = new[] { "==", "!=", "<", "<=", ">", ">=" };
+                var enumValues = Enum.GetValues<Direction>();
+
+                foreach (var enumValue in enumValues)
+                {
+                    foreach (var enumValue2 in enumValues)
+                    {
+                        yield return new TestCaseData("==", enumValue, enumValue2, enumValue == enumValue2);
+                        yield return new TestCaseData("!=", enumValue, enumValue2, enumValue != enumValue2);
+                        yield return new TestCaseData("<", enumValue, enumValue2, enumValue < enumValue2);
+                        yield return new TestCaseData("<=", enumValue, enumValue2, enumValue <= enumValue2);
+                        yield return new TestCaseData(">", enumValue, enumValue2, enumValue > enumValue2);
+                        yield return new TestCaseData(">=", enumValue, enumValue2, enumValue >= enumValue2);
+                    }
+                }
+            }
+        }
+
+        [TestCaseSource(nameof(SameEnumTypeComparisonOperatorsTestCases))]
+        public void SameEnumTypeComparisonOperatorsWorkWithoutExplicitCast(string @operator, Direction operand1, Direction operand2, bool expectedResult)
+        {
+            using var _ = Py.GIL();
+            var module = PyModule.FromString("SameEnumTypeComparisonOperatorsWorkWithoutExplicitCast", $@"
+from clr import AddReference
+AddReference(""Python.EmbeddingTest"")
+
+from Python.EmbeddingTest import *
+
+def operation():
+    return {nameof(EnumTests)}.{nameof(Direction)}.{operand1} {@operator} {nameof(EnumTests)}.{nameof(Direction)}.{operand2}
+");
+
+            Assert.AreEqual(expectedResult, module.InvokeMethod("operation").As<bool>());
+        }
+
+        [TestCase("==", Direction.Down, "Down", true)]
+        [TestCase("==", Direction.Down, "Flat", false)]
+        [TestCase("==", Direction.Down, "Up", false)]
+        [TestCase("==", Direction.Flat, "Down", false)]
+        [TestCase("==", Direction.Flat, "Flat", true)]
+        [TestCase("==", Direction.Flat, "Up", false)]
+        [TestCase("==", Direction.Up, "Down", false)]
+        [TestCase("==", Direction.Up, "Flat", false)]
+        [TestCase("==", Direction.Up, "Up", true)]
+        [TestCase("!=", Direction.Down, "Down", false)]
+        [TestCase("!=", Direction.Down, "Flat", true)]
+        [TestCase("!=", Direction.Down, "Up", true)]
+        [TestCase("!=", Direction.Flat, "Down", true)]
+        [TestCase("!=", Direction.Flat, "Flat", false)]
+        [TestCase("!=", Direction.Flat, "Up", true)]
+        [TestCase("!=", Direction.Up, "Down", true)]
+        [TestCase("!=", Direction.Up, "Flat", true)]
+        [TestCase("!=", Direction.Up, "Up", false)]
+        public void EnumComparisonOperatorsWorkWithString(string @operator, Direction operand1, string operand2, bool expectedResult)
+        {
+            using var _ = Py.GIL();
+            var module = PyModule.FromString("EnumComparisonOperatorsWorkWithString", $@"
+from clr import AddReference
+AddReference(""Python.EmbeddingTest"")
+
+from Python.EmbeddingTest import *
+
+def operation1():
+    return {nameof(EnumTests)}.{nameof(Direction)}.{operand1} {@operator} ""{operand2}""
+
+def operation2():
+    return ""{operand2}"" {@operator} {nameof(EnumTests)}.{nameof(Direction)}.{operand1}
+");
+
+            Assert.AreEqual(expectedResult, module.InvokeMethod("operation1").As<bool>());
+            Assert.AreEqual(expectedResult, module.InvokeMethod("operation2").As<bool>());
+        }
+    }
+}

--- a/src/runtime/Converter.cs
+++ b/src/runtime/Converter.cs
@@ -226,6 +226,11 @@ class GMT(tzinfo):
                 return resultlist.NewReferenceOrNull();
             }
 
+            if (type.IsEnum)
+            {
+                return CLRObject.GetReference(value, type);
+            }
+
             // it the type is a python subclass of a managed type then return the
             // underlying python object rather than construct a new wrapper object.
             var pyderived = value as IPythonDerivedType;

--- a/src/runtime/MethodBinder.cs
+++ b/src/runtime/MethodBinder.cs
@@ -383,6 +383,17 @@ namespace Python.Runtime
                 return 3000;
             }
 
+            if (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(Nullable<>))
+            {
+                // Nullable<T> is a special case, we treat it as the underlying type
+                return ArgPrecedence(Nullable.GetUnderlyingType(t), isOperatorMethod);
+            }
+
+            if (t.IsEnum)
+            {
+                return -2;
+            }
+
             if (t.IsAssignableFrom(typeof(PyObject)) && !isOperatorMethod)
             {
                 return -1;

--- a/src/runtime/Util/OpsHelper.cs
+++ b/src/runtime/Util/OpsHelper.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Linq.Expressions;
 using System.Reflection;
-
 using static Python.Runtime.OpsHelper;
 
 namespace Python.Runtime
@@ -35,7 +34,7 @@ namespace Python.Runtime
     }
 
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
-    internal class OpsAttribute: Attribute { }
+    internal class OpsAttribute : Attribute { }
 
     [Ops]
     internal static class FlagEnumOps<T> where T : Enum
@@ -85,5 +84,400 @@ namespace Python.Runtime
             => typeof(T).GetEnumUnderlyingType() == typeof(UInt64)
             ? new PyInt(Convert.ToUInt64(value))
             : new PyInt(Convert.ToInt64(value));
+
+        #region Arithmetic operators
+
+        public static double op_Addition(T a, double b)
+        {
+            if (typeof(T).GetEnumUnderlyingType() == typeof(UInt64))
+            {
+                return Convert.ToUInt64(a) + b;
+            }
+            return Convert.ToInt64(a) + b;
+        }
+
+        public static double op_Addition(double a, T b)
+        {
+            return op_Addition(b, a);
+        }
+
+        public static double op_Subtraction(T a, double b)
+        {
+            if (typeof(T).GetEnumUnderlyingType() == typeof(UInt64))
+            {
+                return Convert.ToUInt64(a) - b;
+            }
+            return Convert.ToInt64(a) - b;
+        }
+
+        public static double op_Subtraction(double a, T b)
+        {
+            return op_Subtraction(b, a);
+        }
+
+        public static double op_Multiply(T a, double b)
+        {
+            if (typeof(T).GetEnumUnderlyingType() == typeof(UInt64))
+            {
+                return Convert.ToUInt64(a) * b;
+            }
+            return Convert.ToInt64(a) * b;
+        }
+
+        public static double op_Multiply(double a, T b)
+        {
+            return op_Multiply(b, a);
+        }
+
+        public static double op_Division(T a, double b)
+        {
+            if (typeof(T).GetEnumUnderlyingType() == typeof(UInt64))
+            {
+                return Convert.ToUInt64(a) / b;
+            }
+            return Convert.ToInt64(a) / b;
+        }
+
+        public static double op_Division(double a, T b)
+        {
+            return op_Division(b, a);
+        }
+
+        #endregion
+
+        #region Int comparison operators
+
+        public static bool op_Equality(T a, long b)
+        {
+            if (typeof(T).GetEnumUnderlyingType() == typeof(UInt64))
+            {
+                var uvalue = Convert.ToUInt64(a);
+                return b >= 0 && ((ulong)b) == uvalue;
+            }
+            return Convert.ToInt64(a) == b;
+        }
+
+        public static bool op_Equality(T a, ulong b)
+        {
+            if (typeof(T).GetEnumUnderlyingType() == typeof(UInt64))
+            {
+                var uvalue = Convert.ToUInt64(a);
+                return b == uvalue;
+            }
+            var ivalue = Convert.ToInt64(a);
+            return ivalue >= 0 && ((ulong)ivalue) == b;
+        }
+
+        public static bool op_Equality(long a, T b)
+        {
+            return op_Equality(b, a);
+        }
+
+        public static bool op_Equality(ulong a, T b)
+        {
+            return op_Equality(b, a);
+        }
+
+        public static bool op_Inequality(T a, long b)
+        {
+            return !op_Equality(a, b);
+        }
+
+        public static bool op_Inequality(T a, ulong b)
+        {
+            return !op_Equality(a, b);
+        }
+
+        public static bool op_Inequality(long a, T b)
+        {
+            return !op_Equality(b, a);
+        }
+
+        public static bool op_Inequality(ulong a, T b)
+        {
+            return !op_Equality(b, a);
+        }
+
+        public static bool op_LessThan(T a, long b)
+        {
+            if (typeof(T).GetEnumUnderlyingType() == typeof(UInt64))
+            {
+                var uvalue = Convert.ToUInt64(a);
+                return b >= 0 && ((ulong)b) > uvalue;
+            }
+            return Convert.ToInt64(a) < b;
+        }
+
+        public static bool op_LessThan(T a, ulong b)
+        {
+            if (typeof(T).GetEnumUnderlyingType() == typeof(UInt64))
+            {
+                var uvalue = Convert.ToUInt64(a);
+                return b > uvalue;
+            }
+            var ivalue = Convert.ToInt64(a);
+            return ivalue >= 0 && ((ulong)ivalue) < b;
+        }
+
+        public static bool op_LessThan(long a, T b)
+        {
+            return op_GreaterThan(b, a);
+        }
+
+        public static bool op_LessThan(ulong a, T b)
+        {
+            return op_GreaterThan(b, a);
+        }
+
+        public static bool op_GreaterThan(T a, long b)
+        {
+            if (typeof(T).GetEnumUnderlyingType() == typeof(UInt64))
+            {
+                var uvalue = Convert.ToUInt64(a);
+                return b >= 0 && ((ulong)b) < uvalue;
+            }
+            return Convert.ToInt64(a) > b;
+        }
+
+        public static bool op_GreaterThan(T a, ulong b)
+        {
+            if (typeof(T).GetEnumUnderlyingType() == typeof(UInt64))
+            {
+                var uvalue = Convert.ToUInt64(a);
+                return b < uvalue;
+            }
+            var ivalue = Convert.ToInt64(a);
+            return ivalue >= 0 && ((ulong)ivalue) > b;
+        }
+
+        public static bool op_GreaterThan(long a, T b)
+        {
+            return op_LessThan(b, a);
+        }
+
+        public static bool op_GreaterThan(ulong a, T b)
+        {
+            return op_LessThan(b, a);
+        }
+
+        public static bool op_LessThanOrEqual(T a, long b)
+        {
+            if (typeof(T).GetEnumUnderlyingType() == typeof(UInt64))
+            {
+                var uvalue = Convert.ToUInt64(a);
+                return b >= 0 && ((ulong)b) >= uvalue;
+            }
+            return Convert.ToInt64(a) <= b;
+        }
+
+        public static bool op_LessThanOrEqual(T a, ulong b)
+        {
+            if (typeof(T).GetEnumUnderlyingType() == typeof(UInt64))
+            {
+                var uvalue = Convert.ToUInt64(a);
+                return b >= uvalue;
+            }
+            var ivalue = Convert.ToInt64(a);
+            return ivalue >= 0 && ((ulong)ivalue) <= b;
+        }
+
+        public static bool op_LessThanOrEqual(long a, T b)
+        {
+            return op_GreaterThanOrEqual(b, a);
+        }
+
+        public static bool op_LessThanOrEqual(ulong a, T b)
+        {
+            return op_GreaterThanOrEqual(b, a);
+        }
+
+        public static bool op_GreaterThanOrEqual(T a, long b)
+        {
+            if (typeof(T).GetEnumUnderlyingType() == typeof(UInt64))
+            {
+                var uvalue = Convert.ToUInt64(a);
+                return b >= 0 && ((ulong)b) <= uvalue;
+            }
+            return Convert.ToInt64(a) >= b;
+        }
+
+        public static bool op_GreaterThanOrEqual(T a, ulong b)
+        {
+            if (typeof(T).GetEnumUnderlyingType() == typeof(UInt64))
+            {
+                var uvalue = Convert.ToUInt64(a);
+                return b <= uvalue;
+            }
+            var ivalue = Convert.ToInt64(a);
+            return ivalue >= 0 && ((ulong)ivalue) >= b;
+        }
+
+        public static bool op_GreaterThanOrEqual(long a, T b)
+        {
+            return op_LessThanOrEqual(b, a);
+        }
+
+        public static bool op_GreaterThanOrEqual(ulong a, T b)
+        {
+            return op_LessThanOrEqual(b, a);
+        }
+
+        #endregion
+
+        #region Double comparison operators
+
+        public static bool op_Equality(T a, double b)
+        {
+            if (typeof(T).GetEnumUnderlyingType() == typeof(UInt64))
+            {
+                return Convert.ToUInt64(a) == b;
+            }
+            return Convert.ToInt64(a) == b;
+        }
+
+        public static bool op_Equality(double a, T b)
+        {
+            return op_Equality(b, a);
+        }
+
+        public static bool op_Inequality(T a, double b)
+        {
+            return !op_Equality(a, b);
+        }
+
+        public static bool op_Inequality(double a, T b)
+        {
+            return !op_Equality(b, a);
+        }
+
+        public static bool op_LessThan(T a, double b)
+        {
+            if (typeof(T).GetEnumUnderlyingType() == typeof(UInt64))
+            {
+                return Convert.ToUInt64(a) < b;
+            }
+            return Convert.ToInt64(a) < b;
+        }
+
+        public static bool op_LessThan(double a, T b)
+        {
+            return op_GreaterThan(b, a);
+        }
+
+        public static bool op_GreaterThan(T a, double b)
+        {
+            if (typeof(T).GetEnumUnderlyingType() == typeof(UInt64))
+            {
+                return Convert.ToUInt64(a) > b;
+            }
+            return Convert.ToInt64(a) > b;
+        }
+
+        public static bool op_GreaterThan(double a, T b)
+        {
+            return op_LessThan(b, a);
+        }
+
+        public static bool op_LessThanOrEqual(T a, double b)
+        {
+            if (typeof(T).GetEnumUnderlyingType() == typeof(UInt64))
+            {
+                return Convert.ToUInt64(a) <= b;
+            }
+            return Convert.ToInt64(a) <= b;
+        }
+
+        public static bool op_LessThanOrEqual(double a, T b)
+        {
+            return op_GreaterThanOrEqual(b, a);
+        }
+
+        public static bool op_GreaterThanOrEqual(T a, double b)
+        {
+            if (typeof(T).GetEnumUnderlyingType() == typeof(UInt64))
+            {
+                return Convert.ToUInt64(a) >= b;
+            }
+            return Convert.ToInt64(a) >= b;
+        }
+
+        public static bool op_GreaterThanOrEqual(double a, T b)
+        {
+            return op_LessThanOrEqual(b, a);
+        }
+
+        #endregion
+
+        #region Same type comparison operators
+
+        public static bool op_Equality(T a, T b)
+        {
+            return a.Equals(b);
+        }
+
+        public static bool op_Inequality(T a, T b)
+        {
+            return !a.Equals(b);
+        }
+
+        public static bool op_LessThan(T a, T b)
+        {
+            if (typeof(T).GetEnumUnderlyingType() == typeof(UInt64))
+            {
+                return Convert.ToUInt64(a) < Convert.ToUInt64(b);
+            }
+            return Convert.ToInt64(a) < Convert.ToInt64(b);
+        }
+
+        public static bool op_GreaterThan(T a, T b)
+        {
+            if (typeof(T).GetEnumUnderlyingType() == typeof(UInt64))
+            {
+                return Convert.ToUInt64(a) > Convert.ToUInt64(b);
+            }
+            return Convert.ToInt64(a) > Convert.ToInt64(b);
+        }
+
+        public static bool op_LessThanOrEqual(T a, T b)
+        {
+            if (typeof(T).GetEnumUnderlyingType() == typeof(UInt64))
+            {
+                return Convert.ToUInt64(a) <= Convert.ToUInt64(b);
+            }
+            return Convert.ToInt64(a) <= Convert.ToInt64(b);
+        }
+
+        public static bool op_GreaterThanOrEqual(T a, T b)
+        {
+            if (typeof(T).GetEnumUnderlyingType() == typeof(UInt64))
+            {
+                return Convert.ToUInt64(a) >= Convert.ToUInt64(b);
+            }
+            return Convert.ToInt64(a) >= Convert.ToInt64(b);
+        }
+
+        #endregion
+
+        #region String comparison operators
+        public static bool op_Equality(T a, string b)
+        {
+            return a.ToString().Equals(b, StringComparison.InvariantCultureIgnoreCase);
+        }
+        public static bool op_Equality(string a, T b)
+        {
+            return op_Equality(b, a);
+        }
+
+        public static bool op_Inequality(T a, string b)
+        {
+            return !op_Equality(a, b);
+        }
+
+        public static bool op_Inequality(string a, T b)
+        {
+            return !op_Equality(b, a);
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
Avoid converting C# enums to long in Python and make them work as actual C# enums in Python.

Part of https://github.com/QuantConnect/Lean/issues/8627
