### PR TITLE
Include the probed PythonDLL value in the load exception

### DIFF
--- a/src/runtime/Runtime.Delegates.cs
+++ b/src/runtime/Runtime.Delegates.cs
@@ -301,7 +301,8 @@ public unsafe partial class Runtime
             {
                 throw new BadPythonDllException(
                     "Runtime.PythonDLL was not set or does not point to a supported Python runtime DLL." +
-                    " See https://github.com/pythonnet/pythonnet#embedding-python-in-net",
+                    " See https://github.com/pythonnet/pythonnet#embedding-python-in-net." +
+                    $" Value of PythonDLL: {PythonDLL ?? "null"}",
                     e);
             }
         }


### PR DESCRIPTION
Cherry-pick from upstream `pythonnet/pythonnet` to improve the diagnostic when the Python shared library fails to load — the exception now includes the probed `PythonDLL` value.

- Upstream commit: pythonnet/pythonnet@40a3db7276423fb89c2742ac6d93572f53312ba1 ("Include the probed PythonDLL value in the exception", by Benedikt Reinartz)
- Cherry-picked with `-x` (original authorship preserved).

Low-risk, diagnostics-only. Opening for review/decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)