### PR TITLE
Fix MethodBinding/OverloadMapper memory leak

### DIFF
--- a/src/runtime/PythonTypes/PyObject.cs
+++ b/src/runtime/PythonTypes/PyObject.cs
@@ -93,6 +93,12 @@ namespace Python.Runtime
             Finalizer.Instance.ThrottledCollect();
         }
 
+        /// <summary>
+        /// Create a new PyObject instance of this object, bumping the reference
+        /// count.
+        /// </summary>
+        public PyObject NewReference() => new(this);
+
         // Ensure that encapsulated Python object is decref'ed appropriately
         // when the managed wrapper is garbage-collected.
         ~PyObject()

--- a/src/runtime/PythonTypes/PyType.cs
+++ b/src/runtime/PythonTypes/PyType.cs
@@ -35,6 +35,12 @@ namespace Python.Runtime
                 throw new ArgumentException("object is not a type");
         }
 
+        /// <summary>
+        /// Create a new PyType instance of this object, bumping the reference
+        /// count.
+        /// </summary>
+        public new PyType NewReference() => new(this);
+
         protected PyType(SerializationInfo info, StreamingContext context) : base(info, context) { }
 
         internal new static PyType? FromNullableReference(BorrowedReference reference)

--- a/src/runtime/Types/ExtensionType.cs
+++ b/src/runtime/Types/ExtensionType.cs
@@ -79,8 +79,18 @@ namespace Python.Runtime
             DecrefTypeAndFree(lastRef.Steal());
         }
 
+        /// <summary>
+        /// Called during tp_clear before the GCHandle is released.
+        /// Override to eagerly dispose Python object references (PyObject fields)
+        /// held by the subclass, preventing the multi-hop .NET finalizer chain
+        /// from delaying Python-side refcount decrements.
+        /// </summary>
+        protected virtual void OnClear() { }
+
         public static int tp_clear(BorrowedReference ob)
         {
+            (GetManagedObject(ob) as ExtensionType)?.OnClear();
+
             var weakrefs = Runtime.PyObject_GetWeakRefList(ob);
             if (weakrefs != null)
             {

--- a/src/runtime/Types/MethodBinding.cs
+++ b/src/runtime/Types/MethodBinding.cs
@@ -20,14 +20,12 @@ namespace Python.Runtime
         internal MaybeMethodInfo info;
         internal MethodObject m;
         internal PyObject? target;
-        internal PyType? targetType;
+        internal PyType targetType;
 
-        public MethodBinding(MethodObject m, PyObject? target, PyType? targetType = null)
+        public MethodBinding(MethodObject m, PyObject? target, PyType targetType)
         {
             this.target = target;
-
-            this.targetType = targetType ?? target?.GetPythonType();
-
+            this.targetType = targetType;
             this.info = null;
             this.m = m;
         }
@@ -64,7 +62,7 @@ namespace Python.Runtime
             }
 
             MethodObject overloaded = self.m.WithOverloads(overloads);
-            var mb = new MethodBinding(overloaded, self.target, self.targetType);
+            var mb = new MethodBinding(overloaded, self.target?.NewReference(), self.targetType.NewReference());
             return mb.Alloc();
         }
 
@@ -151,7 +149,7 @@ namespace Python.Runtime
                 // FIXME: deprecate __overloads__ soon...
                 case "__overloads__":
                 case "Overloads":
-                    var om = new OverloadMapper(self.m, self.target);
+                    var om = new OverloadMapper(self.m, self.target?.NewReference(), self.targetType.NewReference());
                     return om.Alloc();
                 case "__signature__" when Runtime.InspectModule is not null:
                     var sig = self.Signature;
@@ -261,7 +259,6 @@ namespace Python.Runtime
             }
         }
 
-
         /// <summary>
         /// MethodBinding  __hash__ implementation.
         /// </summary>
@@ -292,6 +289,13 @@ namespace Python.Runtime
             string type = self.target is null ? "unbound" : "bound";
             string name = self.m.name;
             return Runtime.PyString_FromString($"<{type} method '{name}'>");
+        }
+
+        protected override void OnClear()
+        {
+            target?.Dispose();
+            targetType.Dispose();
+            target = null;
         }
     }
 }

--- a/src/runtime/Types/MethodObject.cs
+++ b/src/runtime/Types/MethodObject.cs
@@ -226,8 +226,8 @@ namespace Python.Runtime
                 && obj.inst is IPythonDerivedType
                 && self.type.Value.IsInstanceOfType(obj.inst))
             {
-                var basecls = ClassManager.GetClass(self.type.Value);
-                return new MethodBinding(self, new PyObject(ob), basecls).Alloc();
+                var basecls = ReflectedClrType.GetOrCreate(self.type.Value);
+                return new MethodBinding(self, new PyObject(ob), basecls.NewReference()).Alloc();
             }
 
             return new MethodBinding(self, target: new PyObject(ob), targetType: new PyType(tp)).Alloc();

--- a/src/runtime/Types/OverloadMapper.cs
+++ b/src/runtime/Types/OverloadMapper.cs
@@ -9,12 +9,14 @@ namespace Python.Runtime
     /// </summary>
     internal class OverloadMapper : ExtensionType
     {
-        private MethodObject m;
+        private readonly MethodObject m;
         private PyObject? target;
+        readonly PyType targetType;
 
-        public OverloadMapper(MethodObject m, PyObject? target)
+        public OverloadMapper(MethodObject m, PyObject? target, PyType targetType)
         {
             this.target = target;
+            this.targetType = targetType;
             this.m = m;
         }
 
@@ -42,7 +44,7 @@ namespace Python.Runtime
                 return Exceptions.RaiseTypeError(e);
             }
 
-            var mb = new MethodBinding(self.m, self.target) { info = mi };
+            var mb = new MethodBinding(self.m, self.target?.NewReference(), self.targetType.NewReference()) { info = mi };
             return mb.Alloc();
         }
 
@@ -53,6 +55,13 @@ namespace Python.Runtime
         {
             var self = (OverloadMapper)GetManagedObject(op)!;
             return self.m.GetDocString();
+        }
+
+        protected override void OnClear()
+        {
+            target?.Dispose();
+            targetType.Dispose();
+            target = null;
         }
     }
 }

--- a/tests/test_method.py
+++ b/tests/test_method.py
@@ -961,8 +961,10 @@ def test_getting_generic_method_binding_does_not_leak_memory():
     bytesAllocatedPerIteration = pow(2, 20)  # 1MB
     bytesLeakedPerIteration = processBytesDelta / iterations
 
-    # Allow 50% threshold - this shows the original issue is fixed, which leaks the full allocated bytes per iteration
-    failThresholdBytesLeakedPerIteration = bytesAllocatedPerIteration / 2
+    # Tight 10% threshold: with the fix the per-iteration leak is essentially
+    # zero, while the bug retains the bulk of the 1 MB payload (~600 KB/iter
+    # on 3.14 GIL). 100 KB/iter cleanly distinguishes the two states.
+    failThresholdBytesLeakedPerIteration = bytesAllocatedPerIteration * 0.1
 
     assert bytesLeakedPerIteration < failThresholdBytesLeakedPerIteration
 
@@ -1005,8 +1007,8 @@ def test_getting_overloaded_method_binding_does_not_leak_memory():
     bytesAllocatedPerIteration = pow(2, 20)  # 1MB
     bytesLeakedPerIteration = processBytesDelta / iterations
 
-    # Allow 50% threshold - this shows the original issue is fixed, which leaks the full allocated bytes per iteration
-    failThresholdBytesLeakedPerIteration = bytesAllocatedPerIteration / 2
+    # Tight 10% threshold; see test_getting_generic_method_binding_does_not_leak_memory.
+    failThresholdBytesLeakedPerIteration = bytesAllocatedPerIteration * 0.1
 
     assert bytesLeakedPerIteration < failThresholdBytesLeakedPerIteration
 
@@ -1049,8 +1051,8 @@ def test_getting_method_overloads_binding_does_not_leak_memory():
     bytesAllocatedPerIteration = pow(2, 20)  # 1MB
     bytesLeakedPerIteration = processBytesDelta / iterations
 
-    # Allow 50% threshold - this shows the original issue is fixed, which leaks the full allocated bytes per iteration
-    failThresholdBytesLeakedPerIteration = bytesAllocatedPerIteration / 2
+    # Tight 10% threshold; see test_getting_generic_method_binding_does_not_leak_memory.
+    failThresholdBytesLeakedPerIteration = bytesAllocatedPerIteration * 0.1
 
     assert bytesLeakedPerIteration < failThresholdBytesLeakedPerIteration
 


### PR DESCRIPTION
Cherry-pick from upstream `pythonnet/pythonnet`: fixes a long-standing memory leak in `MethodBinding`/`OverloadMapper` where references to the target/target-type were not owned/disposed.

- Upstream PR: pythonnet/pythonnet#2719 ("Fix MethodBinding/OverloadMapper memory leak", fixes long-standing issue #691), by @greateggsgreg
- Upstream commit: pythonnet/pythonnet@ca323cc1
- Cherry-picked with `-x` (original authorship preserved).

**Conflict note:** small conflicts in `MethodObject.cs`, `OverloadMapper.cs`, and `test_method.py` were resolved against this fork. The fork's `ClassManager.GetClass(t)` is `=> ReflectedClrType.GetOrCreate(t)`, so the upstream form (`ReflectedClrType.GetOrCreate(...).NewReference()`) is equivalent here; the leak fix adds owned references that are disposed in `OnClear`. Builds clean (`Python.Runtime.csproj`). Worth a careful review of the reference-ownership given the fork's divergence.

Relevant to long-running embedded use (e.g. Lean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)