### PR TITLE
Take the GIL in sequence and list wrappers

### DIFF
--- a/src/runtime/CollectionWrappers/ListWrapper.cs
+++ b/src/runtime/CollectionWrappers/ListWrapper.cs
@@ -14,12 +14,14 @@ namespace Python.Runtime.CollectionWrappers
         {
             get
             {
+                using var _ = Py.GIL();
                 var item = Runtime.PyList_GetItem(pyObject, index);
                 var pyItem = new PyObject(item);
                 return pyItem.As<T>()!;
             }
             set
             {
+                using var _ = Py.GIL();
                 var pyItem = value.ToPython();
                 var result = Runtime.PyList_SetItem(pyObject, index, new NewReference(pyItem).Steal());
                 if (result == -1)
@@ -37,6 +39,7 @@ namespace Python.Runtime.CollectionWrappers
             if (IsReadOnly)
                 throw new InvalidOperationException("Collection is read-only");
 
+            using var _ = Py.GIL();
             var pyItem = item.ToPython();
 
             int result = Runtime.PyList_Insert(pyObject, index, pyItem);

--- a/src/runtime/CollectionWrappers/SequenceWrapper.cs
+++ b/src/runtime/CollectionWrappers/SequenceWrapper.cs
@@ -14,10 +14,14 @@ namespace Python.Runtime.CollectionWrappers
         {
             get
             {
-                var size = Runtime.PySequence_Size(pyObject.Reference);
-                if (size == -1)
+                nint size = -1;
                 {
-                    Runtime.CheckExceptionOccurred();
+                    using var _ = Py.GIL();
+                    size = Runtime.PySequence_Size(pyObject.Reference);
+                    if (size == -1)
+                    {
+                        Runtime.CheckExceptionOccurred();
+                    }
                 }
 
                 return checked((int)size);
@@ -38,6 +42,7 @@ namespace Python.Runtime.CollectionWrappers
         {
             if (IsReadOnly)
                 throw new NotImplementedException();
+            using var _ = Py.GIL();
             int result = Runtime.PySequence_DelSlice(pyObject, 0, Count);
             if (result == -1)
             {
@@ -77,12 +82,16 @@ namespace Python.Runtime.CollectionWrappers
             if (index >= Count || index < 0)
                 return false;
 
-            int result = Runtime.PySequence_DelItem(pyObject, index);
 
-            if (result == 0)
-                return true;
+            {
+                using var _ = Py.GIL();
+                int result = Runtime.PySequence_DelItem(pyObject, index);
 
-            Runtime.CheckExceptionOccurred();
+                if (result == 0)
+                    return true;
+
+                Runtime.CheckExceptionOccurred();
+            }
             return false;
         }
 


### PR DESCRIPTION
Cherry-pick from upstream `pythonnet/pythonnet`: acquire the GIL in `ListWrapper`/`SequenceWrapper` before calling into CPython, matching the GIL-safety the fork already applies to methods/properties/fields. Prevents crashes / heap corruption when .NET enumerates wrapped sequences off the GIL.

- Upstream commit: pythonnet/pythonnet@698bf009 ("Take the GIL in sequence and list wrappers", by Benedikt Reinartz)
- Cherry-picked with `-x` (original authorship preserved). Applied cleanly; builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)