### PR TITLE
Fix: name missing from __all__ on re-import

### DIFF
--- a/src/runtime/Types/ModuleObject.cs
+++ b/src/runtime/Types/ModuleObject.cs
@@ -20,6 +20,7 @@ namespace Python.Runtime
         internal PyDict dict;
         protected string _namespace;
         private readonly PyList __all__ = new ();
+        private readonly HashSet<string> allNames = new();
 
         // Attributes to be set on the module according to PEP302 and 451
         // by the import machinery.
@@ -179,22 +180,23 @@ namespace Python.Runtime
         {
             foreach (string name in AssemblyManager.GetNames(_namespace))
             {
-                cache.TryGetValue(name, out var m);
-                if (m != null)
+                bool hasValidAttribute = cache.TryGetValue(name, out var m);
+                if (!hasValidAttribute)
                 {
-                    continue;
-                }
-                BorrowedReference attr = Runtime.PyDict_GetItemString(dict, name);
-                // If __dict__ has already set a custom property, skip it.
-                if (!attr.IsNull)
-                {
-                    continue;
+                    BorrowedReference attr = Runtime.PyDict_GetItemString(dict, name);
+                    // If __dict__ has already set a custom property, skip it.
+                    if (!attr.IsNull)
+                    {
+                        continue;
+                    }
+
+                    using var attrVal = GetAttribute(name, true);
+                    hasValidAttribute = !attrVal.IsNull();
                 }
 
-                using var attrVal = GetAttribute(name, true);
-                if (!attrVal.IsNull())
+                if (hasValidAttribute && allNames.Add(name))
                 {
-                    // if it's a valid attribute, add it to __all__
+                    // if it's a valid attribute, add it to __all__ once.
                     using var pyname = Runtime.PyString_FromString(name);
                     if (Runtime.PyList_Append(__all__, pyname.Borrow()) != 0)
                     {

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -5,6 +5,11 @@
 import pytest
 import sys
 
+# Unused import to preload the class
+#
+# This resulted in the FileStream name missing from the wildcard import later
+from System.IO import FileStream  # noqa: F401
+
 def test_relative_missing_import():
     """Test that a relative missing import doesn't crash.
     Some modules use this to check if a package is installed.


### PR DESCRIPTION
Cherry-pick from upstream `pythonnet/pythonnet`: fixes a name missing from a module's `__all__` when a CLR namespace is re-imported.

- Upstream PR: pythonnet/pythonnet#2717
- Upstream commit: pythonnet/pythonnet@dc69411d (by Benedikt Reinartz)
- Cherry-picked with `-x` (original authorship preserved). Applied cleanly; builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)