### PR TITLE
Properly detect availability of BinaryFormatter

### DIFF
--- a/src/runtime/StateSerialization/RuntimeData.cs
+++ b/src/runtime/StateSerialization/RuntimeData.cs
@@ -17,7 +17,36 @@ namespace Python.Runtime
 {
     public static class RuntimeData
     {
-        private static Type? _formatterType;
+
+        public readonly static Func<IFormatter> DefaultFormatterFactory = () =>
+        {
+            try
+            {
+                var res = new BinaryFormatter();
+                res.Serialize(new MemoryStream(), 1); // test if BinaryFormatter is usable
+                return res;
+            }
+            catch
+            {
+                return new NoopFormatter();
+            }
+        };
+
+        private static Func<IFormatter> _formatterFactory { get; set; } = DefaultFormatterFactory;
+
+        public static Func<IFormatter> FormatterFactory
+        {
+            get => _formatterFactory;
+            set
+            {
+                if (value == null)
+                    throw new ArgumentNullException(nameof(value));
+
+                _formatterFactory = value;
+            }
+        }
+
+        private static Type? _formatterType = null;
         public static Type? FormatterType
         {
             get => _formatterType;
@@ -206,7 +235,7 @@ namespace Python.Runtime
         {
             return FormatterType != null ?
                 (IFormatter)Activator.CreateInstance(FormatterType)
-                : new BinaryFormatter();
+                : FormatterFactory();
         }
     }
 }


### PR DESCRIPTION
Cherry-pick from upstream `pythonnet/pythonnet`: avoids throwing when `BinaryFormatter` is unavailable (it's removed/disabled on modern .NET, incl. net10). Adds a `DefaultFormatterFactory` that probes `BinaryFormatter` once and falls back to `NoopFormatter`, plus a settable `FormatterFactory`.

- Upstream PR: pythonnet/pythonnet#2639
- Upstream commit: pythonnet/pythonnet@0258688e (by Benedikt Reinartz)
- Cherry-picked with `-x` (original authorship preserved).

**Conflict note:** `RuntimeData.cs` diverged in this fork. Resolved by taking the upstream factory and **wiring this fork's `CreateFormatter()` fallback to `FormatterFactory()`** (it previously did `new BinaryFormatter()` directly, which is what would throw on net10). The `FormatterType` override path is preserved. Builds clean.

Relevant since this fork targets net10 where `BinaryFormatter` serialization is no longer supported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)