### PR TITLE
Add DLR get/set support (IDynamicMetaObjectProvider)

### DIFF
--- a/src/runtime/InteropConfiguration.cs
+++ b/src/runtime/InteropConfiguration.cs
@@ -20,9 +20,9 @@ namespace Python.Runtime
             {
                 PythonBaseTypeProviders =
                 {
-                    DefaultBaseTypeProvider.Instance
-                    // see https://github.com/pythonnet/pythonnet/issues/1785
-                    // new CollectionMixinsProvider(new Lazy<PyObject>(() => Py.Import("clr._extras.collections"))),
+                    DefaultBaseTypeProvider.Instance,
+                    new CollectionMixinsProvider(new Lazy<PyObject>(() => Py.Import("clr._extras.collections"))),
+                    new DynamicObjectMixinsProvider(new Lazy<PyObject>(() => Py.Import("clr._extras.dlr"))),
                 },
             };
         }

--- a/src/runtime/Mixins/DynamicObjectMixinsProvider.cs
+++ b/src/runtime/Mixins/DynamicObjectMixinsProvider.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Dynamic;
+
+namespace Python.Runtime.Mixins;
+
+class DynamicObjectMixinsProvider : IPythonBaseTypeProvider, IDisposable
+{
+    readonly Lazy<PyObject> mixinsModule;
+
+    public DynamicObjectMixinsProvider(Lazy<PyObject> mixinsModule) =>
+		this.mixinsModule = mixinsModule ?? throw new ArgumentNullException(nameof(mixinsModule));
+
+    public PyObject Mixins => mixinsModule.Value;
+
+    public IEnumerable<PyType> GetBaseTypes(Type type, IList<PyType> existingBases)
+    {
+        if (type is null)
+            throw new ArgumentNullException(nameof(type));
+
+        if (existingBases is null)
+            throw new ArgumentNullException(nameof(existingBases));
+
+        if (!typeof(IDynamicMetaObjectProvider).IsAssignableFrom(type))
+            return existingBases;
+
+        var newBases = new List<PyType>(existingBases)
+        {
+            new(Mixins.GetAttr("DynamicMetaObjectProviderMixin"))
+        };
+
+        if (type.IsInterface && type.BaseType is null)
+        {
+            newBases.RemoveAll(@base => PythonReferenceComparer.Instance.Equals(@base, Runtime.PyBaseObjectType));
+        }
+
+        return newBases;
+    }
+
+    public void Dispose()
+    {
+        if (this.mixinsModule.IsValueCreated)
+        {
+            this.mixinsModule.Value.Dispose();
+        }
+    }
+}

--- a/src/runtime/Mixins/dlr.py
+++ b/src/runtime/Mixins/dlr.py
@@ -1,0 +1,18 @@
+"""
+Implements helpers for Dynamic Language Runtime (DLR) types.
+"""
+
+class DynamicMetaObjectProviderMixin:
+    def __dir__(self):
+        names = set(super().__dir__())
+
+        get_dynamic_member_names = getattr(self, "GetDynamicMemberNames", None)
+        if callable(get_dynamic_member_names):
+            try:
+                for name in get_dynamic_member_names():
+                    if isinstance(name, str):
+                        names.add(name)
+            except Exception:
+                pass
+
+        return list(sorted(names))

--- a/src/runtime/PythonEngine.cs
+++ b/src/runtime/PythonEngine.cs
@@ -291,7 +291,7 @@ namespace Python.Runtime
 
         static void LoadMixins(BorrowedReference targetModuleDict)
         {
-            foreach (string nested in new[] { "collections" })
+            foreach (string nested in new[] { "collections", "dlr" })
             {
                 LoadSubmodule(targetModuleDict,
                     fullName: "clr._extras." + nested,

--- a/src/runtime/TypeManager.cs
+++ b/src/runtime/TypeManager.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Dynamic;
 using System.Linq;
@@ -41,8 +42,14 @@ namespace Python.Runtime
 
         static readonly DynamicObjectMemberAccessor dynamicMemberAccessor = new();
 
+        // tp_getattro_dlr_proxy / tp_setattro_dlr_proxy hit HasClrMember on every
+        // attribute access; cache the reflection result per (Type, name).
+        static readonly ConcurrentDictionary<(Type, string), bool> _hasClrMemberCache = new();
+
         static bool HasClrMember(object instance, string memberName) =>
-            instance.GetType().GetMember(memberName, BindingFlags.Public | BindingFlags.Instance).Length > 0;
+            _hasClrMemberCache.GetOrAdd(
+                (instance.GetType(), memberName),
+                k => k.Item1.GetMember(k.Item2, BindingFlags.Public | BindingFlags.Instance).Length > 0);
 
         static bool IsPythonSpecialAttributeName(string memberName) =>
             memberName.Length > 4 && memberName.StartsWith("__") && memberName.EndsWith("__");
@@ -198,7 +205,9 @@ namespace Python.Runtime
                 }
                 catch (Exception e)
                 {
-                    Exceptions.SetError(e);
+                    // Same reasoning as the getter: avoid Converter.ToPython(e) to keep this
+                    // slot re-entry-safe on live dynamic objects.
+                    Exceptions.SetError(Exceptions.RuntimeError, e.Message);
                     return -1;
                 }
 

--- a/src/runtime/TypeManager.cs
+++ b/src/runtime/TypeManager.cs
@@ -123,8 +123,13 @@ namespace Python.Runtime
             {
                 resolved = dynamicMemberAccessor.TryGetMember(dynamicObject, memberName, out value);
             }
-            catch
+            catch (Exception e)
             {
+                // Avoid wrapping the CLR exception via Converter.ToPython here: that would trigger
+                // CLR type initialisation which can re-enter this slot on the same live object,
+                // causing infinite recursion. A plain RuntimeError with the message is safe.
+                Runtime.PyErr_Clear();
+                Exceptions.SetError(Exceptions.RuntimeError, e.Message);
                 return default;
             }
 

--- a/src/runtime/TypeManager.cs
+++ b/src/runtime/TypeManager.cs
@@ -169,19 +169,32 @@ namespace Python.Runtime
             if (!HasClrMember(instance, memberName) && !IsPythonSpecialAttributeName(memberName))
             {
                 // Try DLR member storage first
-                bool handled = false;
+                bool handled;
 
-                if (val == null)
+                try
                 {
-                    handled = dynamicMemberAccessor.TryDeleteMember(dynamicObject, memberName);
+                    if (val.IsNull)
+                    {
+                        handled = dynamicMemberAccessor.TryDeleteMember(dynamicObject, memberName);
+                    }
+                    else
+                    {
+                        object? managedValue = null;
+                        if (val != Runtime.PyNone && !Converter.ToManaged(val, typeof(object), out managedValue, true))
+                            return -1;
+
+                        handled = dynamicMemberAccessor.TrySetMember(dynamicObject, memberName, managedValue);
+                        if (!handled)
+                        {
+                            Exceptions.SetError(Exceptions.AttributeError, $"'{instance.GetType().Name}' object has no attribute '{memberName}'");
+                            return -1;
+                        }
+                    }
                 }
-                else
+                catch (Exception e)
                 {
-                    object? managedValue = null;
-                    if (val != Runtime.PyNone && !Converter.ToManaged(val, typeof(object), out managedValue, true))
-                        return -1;
-
-                    handled = dynamicMemberAccessor.TrySetMember(dynamicObject, memberName, managedValue);
+                    Exceptions.SetError(e);
+                    return -1;
                 }
 
                 if (handled)

--- a/src/runtime/TypeManager.cs
+++ b/src/runtime/TypeManager.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.Dynamic;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Diagnostics;
+
 using Python.Runtime.Native;
 using Python.Runtime.StateSerialization;
 
@@ -37,10 +39,164 @@ namespace Python.Runtime
             "tp_clear",
         };
 
+        static readonly DynamicObjectMemberAccessor dynamicMemberAccessor = new();
+
+        static bool HasClrMember(object instance, string memberName) =>
+            instance.GetType().GetMember(memberName, BindingFlags.Public | BindingFlags.Instance).Length > 0;
+
+        static bool IsPythonSpecialAttributeName(string memberName) =>
+            memberName.Length > 4 && memberName.StartsWith("__") && memberName.EndsWith("__");
+
+        static bool TryGetDynamicInstance(BorrowedReference ob, out object instance, out IDynamicMetaObjectProvider dynamicObject)
+        {
+            if (ManagedType.GetManagedObject(ob) is CLRObject co && co.inst is IDynamicMetaObjectProvider coDynamic)
+            {
+                instance = co.inst;
+                dynamicObject = coDynamic;
+                return true;
+            }
+
+            if (Converter.ToManaged(ob, typeof(IDynamicMetaObjectProvider), out object? managedDynamic, false)
+                && managedDynamic is IDynamicMetaObjectProvider convertedDynamic)
+            {
+                instance = managedDynamic;
+                dynamicObject = convertedDynamic;
+                return true;
+            }
+
+            if (Converter.ToManaged(ob, typeof(object), out object? managedInstance, false)
+                && managedInstance is IDynamicMetaObjectProvider boxedDynamic)
+            {
+                instance = managedInstance;
+                dynamicObject = boxedDynamic;
+                return true;
+            }
+
+            instance = null!;
+            dynamicObject = null!;
+            return false;
+        }
+
+        public static NewReference tp_getattro_dlr_proxy(BorrowedReference ob, BorrowedReference key)
+        {
+            var isDynamic = TryGetDynamicInstance(ob, out object instance, out IDynamicMetaObjectProvider dynamicObject);
+
+            // The whole DLR machinery only makes sense with string keys and dynamic objects
+            if (!isDynamic || !Runtime.PyString_Check(key))
+            {
+                return Runtime.PyObject_GenericGetAttr(ob, key);
+            }
+
+            string memberName = Runtime.GetManagedString(key)!;
+
+            // Forward requests to GetDynamicMemberNames to the mixin implementation
+            if (memberName == nameof(DynamicObjectMemberAccessor.GetDynamicMemberNames)
+                && !HasClrMember(instance, memberName))
+            {
+                using var pyMemberNames = new Func<IReadOnlyCollection<string>>(
+                    () => dynamicMemberAccessor.GetDynamicMemberNames(dynamicObject)
+                ).ToPython();
+                return pyMemberNames.NewReferenceOrNull();
+            }
+
+            // Now, first try to access the Python attribute
+            var attr = Runtime.PyObject_GenericGetAttr(ob, key);
+            if (!attr.IsNull())
+                return attr;
+
+            // attr is null, so an exception must be set. If that exception is not an AttributeError,
+            // we return from this function immediately without clearing. All later returns until the
+            // very end will lead to the AttributeError getting raised.
+            if (Runtime.PyErr_ExceptionMatches(Exceptions.AttributeError) == 0)
+            {
+                return default;
+            }
+
+            if (HasClrMember(instance, memberName) || IsPythonSpecialAttributeName(memberName))
+            {
+                return default;
+            }
+
+            bool resolved = false;
+            object? value = null;
+            try
+            {
+                resolved = dynamicMemberAccessor.TryGetMember(dynamicObject, memberName, out value);
+            }
+            catch
+            {
+                return default;
+            }
+
+            if (!resolved)
+            {
+                return default;
+            }
+
+            Runtime.PyErr_Clear();
+
+            using var pyValue = value.ToPython();
+            return pyValue.NewReferenceOrNull();
+        }
+
+        public static int tp_setattro_dlr_proxy(BorrowedReference ob, BorrowedReference key, BorrowedReference val)
+        {
+            var isDynamic = TryGetDynamicInstance(ob, out object instance, out IDynamicMetaObjectProvider dynamicObject);
+
+            // The whole DLR machinery only makes sense with string keys and dynamic objects
+            if (!isDynamic || !Runtime.PyString_Check(key))
+            {
+                return Runtime.PyObject_GenericSetAttr(ob, key, val);
+            }
+
+            string memberName = Runtime.GetManagedString(key)!;
+
+            // For Python-derived types (IPythonDerivedType), the Python descriptor protocol
+            // (e.g. @property setters) takes priority over DLR member storage.
+            if (instance is IPythonDerivedType)
+            {
+                int pyResult = Runtime.PyObject_GenericSetAttr(ob, key, val);
+                if (pyResult == 0)
+                    return 0;
+
+                if (Runtime.PyErr_ExceptionMatches(Exceptions.AttributeError) == 0)
+                    return pyResult;
+
+                Runtime.PyErr_Clear();
+                // Fall through to DLR fallback below
+            }
+
+            if (!HasClrMember(instance, memberName) && !IsPythonSpecialAttributeName(memberName))
+            {
+                // Try DLR member storage first
+                bool handled = false;
+
+                if (val == null)
+                {
+                    handled = dynamicMemberAccessor.TryDeleteMember(dynamicObject, memberName);
+                }
+                else
+                {
+                    object? managedValue = null;
+                    if (val != Runtime.PyNone && !Converter.ToManaged(val, typeof(object), out managedValue, true))
+                        return -1;
+
+                    handled = dynamicMemberAccessor.TrySetMember(dynamicObject, memberName, managedValue);
+                }
+
+                if (handled)
+                    return 0;
+            }
+
+            // Fall back to Python attribute setting
+            return Runtime.PyObject_GenericSetAttr(ob, key, val);
+        }
+
         internal static void Initialize()
         {
             Debug.Assert(cache.Count == 0, "Cache should be empty",
                 "Some errors may occurred on last shutdown");
+            dynamicMemberAccessor.Clear();
             using (var plainType = SlotHelper.CreateObjectType())
             {
                 subtype_traverse = Util.ReadIntPtr(plainType.Borrow(), TypeOffset.tp_traverse);
@@ -63,6 +219,8 @@ namespace Python.Runtime
                     }
                 }
             }
+
+            dynamicMemberAccessor.Clear();
 
             foreach (var type in cache.Values)
             {
@@ -294,6 +452,13 @@ namespace Python.Runtime
             if (!type.IsReady && Runtime.PyType_Ready(type) != 0)
             {
                 throw PythonException.ThrowLastAsClrException();
+            }
+
+            if (typeof(IDynamicMetaObjectProvider).IsAssignableFrom(clrType))
+            {
+                InitializeSlot(type, TypeOffset.tp_getattro, new Interop.BB_N(tp_getattro_dlr_proxy), slotsHolder);
+                InitializeSlot(type, TypeOffset.tp_setattro, new Interop.BBB_I32(tp_setattro_dlr_proxy), slotsHolder);
+                Runtime.PyType_Modified(type.Reference);
             }
 
             var dict = Util.ReadRef(type, TypeOffset.tp_dict);

--- a/src/runtime/Types/ClassDerived.cs
+++ b/src/runtime/Types/ClassDerived.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Dynamic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
@@ -227,6 +228,13 @@ namespace Python.Runtime
                     continue;
                 }
 
+                // Avoid re-entrant DLR binder recursion when Python derives from
+                // DynamicObject-based types (including overrides in intermediate bases).
+                if (IsDynamicObjectHookMethod(method))
+                {
+                    continue;
+                }
+
                 // skip if this property has already been overridden
                 if ((method.Name.StartsWith("get_") || method.Name.StartsWith("set_"))
                     && pyProperties.Contains(method.Name.Substring(4)))
@@ -296,6 +304,35 @@ namespace Python.Runtime
             AssemblyBuilder assemblyBuilder = assemblyBuilders[assemblyName];
 
             return type;
+        }
+
+        static bool IsDynamicObjectHookMethod(MethodInfo method)
+        {
+            MethodInfo origin = method.GetBaseDefinition();
+            Type? originType = origin.DeclaringType;
+            if (originType == typeof(DynamicObject))
+            {
+                return origin.Name switch
+                {
+                    nameof(DynamicObject.TryGetMember)
+                    or nameof(DynamicObject.TrySetMember)
+                    or nameof(DynamicObject.TryDeleteMember)
+                    or nameof(DynamicObject.TryInvokeMember)
+                    or nameof(DynamicObject.TryConvert)
+                    or nameof(DynamicObject.TryGetIndex)
+                    or nameof(DynamicObject.TrySetIndex)
+                    or nameof(DynamicObject.GetDynamicMemberNames)
+                    or nameof(IDynamicMetaObjectProvider.GetMetaObject) => true,
+                    _ => false,
+                };
+            }
+
+            if (originType == typeof(IDynamicMetaObjectProvider))
+            {
+                return origin.Name == nameof(IDynamicMetaObjectProvider.GetMetaObject);
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/src/runtime/Types/DynamicObjectMemberAccessor.cs
+++ b/src/runtime/Types/DynamicObjectMemberAccessor.cs
@@ -1,0 +1,203 @@
+using System;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
+using Microsoft.CSharp.RuntimeBinder;
+
+namespace Python.Runtime;
+
+class DynamicObjectMemberAccessor
+{
+    const int MaxCacheEntries = 1000;
+
+    readonly ConcurrentLruCache<MemberKey, Func<object, object>> getters = new(MaxCacheEntries);
+    readonly ConcurrentLruCache<MemberKey, Action<object, object?>> setters = new(MaxCacheEntries);
+    readonly ConcurrentLruCache<MemberKey, Func<object, bool>> deleters = new(MaxCacheEntries);
+
+    static readonly CSharpArgumentInfo[] getArgumentInfo =
+    {
+        CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null),
+    };
+
+    static readonly CSharpArgumentInfo[] setArgumentInfo =
+    {
+        CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null),
+        CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null),
+    };
+
+    public bool TryGetMember(IDynamicMetaObjectProvider obj, string memberName, out object? value)
+    {
+        if (obj is null)
+            throw new ArgumentNullException(nameof(obj));
+        if (memberName is null)
+            throw new ArgumentNullException(nameof(memberName));
+
+        var getter = getters.GetOrAdd(new MemberKey(obj.GetType(), memberName), static key =>
+        {
+            if (typeof(DynamicObject).IsAssignableFrom(key.Type))
+            {
+                var getBinder = new GetMemberNameBinder(key.MemberName);
+                return obj =>
+                {
+                    if (((DynamicObject)obj).TryGetMember(getBinder, out object? result))
+                    {
+                        return result;
+                    }
+
+                    throw new RuntimeBinderException($"Could not get member '{key.MemberName}'");
+                };
+            }
+
+            var binder = Binder.GetMember(CSharpBinderFlags.None, key.MemberName, key.Type, getArgumentInfo);
+            var callSite = CallSite<Func<CallSite, IDynamicMetaObjectProvider, object>>.Create(binder);
+            return obj => callSite.Target(callSite, (IDynamicMetaObjectProvider)obj);
+        });
+
+        try
+        {
+            value = getter(obj);
+            return true;
+        }
+        catch (RuntimeBinderException)
+        {
+            value = null;
+            return false;
+        }
+    }
+
+    public bool TrySetMember(IDynamicMetaObjectProvider obj, string memberName, object? value)
+    {
+        if (obj is null)
+            throw new ArgumentNullException(nameof(obj));
+        if (memberName is null)
+            throw new ArgumentNullException(nameof(memberName));
+
+        var setter = setters.GetOrAdd(new MemberKey(obj.GetType(), memberName), static key =>
+        {
+            if (typeof(DynamicObject).IsAssignableFrom(key.Type))
+            {
+                var setBinder = new SetMemberNameBinder(key.MemberName);
+                return (obj, value) =>
+                {
+                    if (!((DynamicObject)obj).TrySetMember(setBinder, value))
+                    {
+                        throw new RuntimeBinderException($"Could not set member '{key.MemberName}'");
+                    }
+                };
+            }
+
+            var binder = Binder.SetMember(CSharpBinderFlags.None, key.MemberName, key.Type, setArgumentInfo);
+            var callSite = CallSite<Action<CallSite, IDynamicMetaObjectProvider, object?>>.Create(binder);
+            return (obj, value) => callSite.Target(callSite, (IDynamicMetaObjectProvider)obj, value);
+        });
+
+        try
+        {
+            setter(obj, value);
+            return true;
+        }
+        catch (RuntimeBinderException)
+        {
+            return false;
+        }
+    }
+
+    public bool TryDeleteMember(IDynamicMetaObjectProvider obj, string memberName)
+    {
+        if (obj is null)
+            throw new ArgumentNullException(nameof(obj));
+        if (memberName is null)
+            throw new ArgumentNullException(nameof(memberName));
+
+        var deleter = deleters.GetOrAdd(new MemberKey(obj.GetType(), memberName), static key =>
+        {
+            if (typeof(DynamicObject).IsAssignableFrom(key.Type))
+            {
+                var binder = new DeleteMemberNameBinder(key.MemberName);
+                return obj => ((DynamicObject)obj).TryDeleteMember(binder);
+            }
+
+            if (typeof(ExpandoObject).IsAssignableFrom(key.Type))
+            {
+                return obj => ((IDictionary<string, object>)(ExpandoObject)obj).Remove(key.MemberName);
+            }
+
+            return _ => false;
+        });
+
+        try
+        {
+            return deleter(obj);
+        }
+        catch (RuntimeBinderException)
+        {
+            return false;
+        }
+    }
+
+    public IReadOnlyCollection<string> GetDynamicMemberNames(IDynamicMetaObjectProvider obj)
+    {
+        if (obj is null)
+            throw new ArgumentNullException(nameof(obj));
+
+        if (obj is ExpandoObject expandoObject)
+        {
+            return ((IDictionary<string, object>)expandoObject).Keys.ToArray();
+        }
+
+        if (obj is DynamicObject dynamicObject)
+        {
+            return dynamicObject.GetDynamicMemberNames().ToArray();
+        }
+
+        var metaObject = obj.GetMetaObject(Expression.Constant(obj));
+        return metaObject.GetDynamicMemberNames().ToArray();
+    }
+
+    readonly record struct MemberKey(Type Type, string MemberName);
+
+    sealed class DeleteMemberNameBinder : DeleteMemberBinder
+    {
+        public DeleteMemberNameBinder(string name)
+            : base(name, ignoreCase: false)
+        {
+        }
+
+        public override DynamicMetaObject FallbackDeleteMember(DynamicMetaObject target, DynamicMetaObject? errorSuggestion)
+            => errorSuggestion ?? throw new RuntimeBinderException($"Could not delete member '{Name}'");
+    }
+
+    sealed class GetMemberNameBinder : GetMemberBinder
+    {
+        public GetMemberNameBinder(string name)
+            : base(name, ignoreCase: false)
+        {
+        }
+
+        public override DynamicMetaObject FallbackGetMember(DynamicMetaObject target, DynamicMetaObject? errorSuggestion)
+            => errorSuggestion ?? throw new RuntimeBinderException($"Could not get member '{Name}'");
+    }
+
+    sealed class SetMemberNameBinder : SetMemberBinder
+    {
+        public SetMemberNameBinder(string name)
+            : base(name, ignoreCase: false)
+        {
+        }
+
+        public override DynamicMetaObject FallbackSetMember(
+            DynamicMetaObject target,
+            DynamicMetaObject value,
+            DynamicMetaObject? errorSuggestion)
+            => errorSuggestion ?? throw new RuntimeBinderException($"Could not set member '{Name}'");
+    }
+
+    public void Clear()
+    {
+        getters.Clear();
+        setters.Clear();
+        deleters.Clear();
+    }
+}

--- a/src/runtime/Util/ConcurrentLruCache.cs
+++ b/src/runtime/Util/ConcurrentLruCache.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+namespace Python.Runtime;
+
+internal sealed class ConcurrentLruCache<TKey, TValue> where TKey : notnull
+{
+    readonly ConcurrentDictionary<TKey, LinkedListNode<CacheItem>> map = new();
+    readonly LinkedList<CacheItem> lru = new();
+    readonly object gate = new();
+
+    sealed record CacheItem(TKey Key, TValue Value);
+
+    public ConcurrentLruCache(int capacity)
+    {
+        if (capacity <= 0)
+            throw new ArgumentOutOfRangeException(nameof(capacity), "Capacity must be greater than zero.");
+
+        Capacity = capacity;
+    }
+
+    public int Capacity { get; private set; }
+
+    public int Count => map.Count;
+
+    public TValue GetOrAdd(TKey key, Func<TKey, TValue> valueFactory)
+    {
+        if (valueFactory is null)
+            throw new ArgumentNullException(nameof(valueFactory));
+
+        if (TryGetValue(key, out var existing))
+            return existing;
+
+        var created = valueFactory(key);
+
+        lock (gate)
+        {
+            if (map.TryGetValue(key, out var alreadyAdded))
+            {
+                MoveToFront(alreadyAdded);
+                return alreadyAdded.Value.Value;
+            }
+
+            var item = new CacheItem(key, created);
+            var node = new LinkedListNode<CacheItem>(item);
+            lru.AddFirst(node);
+            map[key] = node;
+            EvictOverflow();
+            return created;
+        }
+    }
+
+    public bool TryGetValue(TKey key, out TValue value)
+    {
+        if (map.TryGetValue(key, out var node))
+        {
+            lock (gate)
+            {
+                if (map.TryGetValue(key, out node))
+                {
+                    MoveToFront(node);
+                    value = node.Value.Value;
+                    return true;
+                }
+            }
+        }
+
+        value = default!;
+        return false;
+    }
+
+    public void Clear()
+    {
+        lock (gate)
+        {
+            lru.Clear();
+            map.Clear();
+        }
+    }
+
+    void MoveToFront(LinkedListNode<CacheItem> node)
+    {
+        if (ReferenceEquals(lru.First, node))
+            return;
+
+        lru.Remove(node);
+        lru.AddFirst(node);
+    }
+
+    void EvictOverflow()
+    {
+        while (map.Count > Capacity)
+        {
+            var last = lru.Last;
+            if (last is null)
+                return;
+
+            lru.RemoveLast();
+            map.TryRemove(last.Value.Key, out _);
+        }
+    }
+}

--- a/src/testing/dlrtest.cs
+++ b/src/testing/dlrtest.cs
@@ -62,6 +62,12 @@ public class RejectingSetDynamicObject : DynamicStorageObject
     }
 }
 
+public class ThrowingGetDynamicObject : DynamicStorageObject
+{
+    public override bool TryGetMember(GetMemberBinder binder, out object result)
+        => throw new InvalidOperationException($"TryGetMember failed for '{binder.Name}'");
+}
+
 public class ThrowingSetDynamicObject : DynamicStorageObject
 {
     public override bool TrySetMember(SetMemberBinder binder, object value)

--- a/src/testing/dlrtest.cs
+++ b/src/testing/dlrtest.cs
@@ -4,24 +4,22 @@ using System.Dynamic;
 
 namespace Python.Test;
 
-public class DynamicMappingObject : DynamicObject
+/// <summary>
+/// Base class for dynamic test helpers. Uses lazy storage initialization so that
+/// Python-derived subclasses can safely call DynamicObject member hooks before
+/// managed field initializers have run.
+/// </summary>
+public class DynamicStorageObject : DynamicObject
 {
     Dictionary<string, object> storage;
 
-    Dictionary<string, object> Storage => storage ??= [];
+    // Python-defined subclasses may reach this type without running managed field
+    // initializers (see ClassDerivedObject.NewObjectToPython). Via the lazy init
+    // we can ensure that the access is still safe, even when the constructor has
+    // not run.
+    protected Dictionary<string, object> Storage => storage ??= [];
 
-    // Native members for testing that regular CLR access is unaffected.
-    public string Label = "default";
-    public int Multiplier { get; set; } = 1;
-    public int Multiply(int value) => value * Multiplier;
-
-    // Test helper: bypass normal member binding and write directly to dynamic storage.
-    public void SetDynamicValue(string name, object value) => Storage[name] = value;
-
-    // Test helper: retrieve the actual value stored in C# (for verification that None was stored as null)
-    public object GetDynamicValue(string name) => Storage.TryGetValue(name, out var value) ? value : null;
-
-
+    public void AddDynamicMember(string name, object value) => Storage[name] = value;
 
     public override bool TryGetMember(GetMemberBinder binder, out object result)
         => Storage.TryGetValue(binder.Name, out result);
@@ -33,7 +31,56 @@ public class DynamicMappingObject : DynamicObject
     }
 
     public override bool TryDeleteMember(DeleteMemberBinder binder)
-        => binder is not null && Storage.Remove(binder.Name);
+        => Storage.Remove(binder.Name);
 
     public override IEnumerable<string> GetDynamicMemberNames() => Storage.Keys;
+}
+
+public class DynamicMappingObject : DynamicStorageObject
+{
+    // Native members for testing that regular CLR access is unaffected.
+    public string Label = "default";
+    public int Multiplier { get; set; } = 1;
+    public int Multiply(int value) => value * Multiplier;
+
+    // Test helper: bypass normal member binding and write directly to dynamic storage.
+    public void SetDynamicValue(string name, object value) => Storage[name] = value;
+
+    // Test helper: retrieve the actual value stored in C# (for verification that None was stored as null)
+    public object GetDynamicValue(string name) => Storage.TryGetValue(name, out var value) ? value : null;
+}
+
+public class RejectingSetDynamicObject : DynamicStorageObject
+{
+    public override bool TrySetMember(SetMemberBinder binder, object value)
+    {
+        if (!Storage.ContainsKey(binder.Name))
+            return false;
+
+        Storage[binder.Name] = value;
+        return true;
+    }
+}
+
+public class ThrowingSetDynamicObject : DynamicStorageObject
+{
+    public override bool TrySetMember(SetMemberBinder binder, object value)
+        => throw new InvalidOperationException($"TrySetMember failed for '{binder.Name}'");
+}
+
+public class RejectingDeleteDynamicObject : DynamicStorageObject
+{
+    public override bool TryDeleteMember(DeleteMemberBinder binder)
+    {
+        if (!Storage.ContainsKey(binder.Name))
+            return false;
+
+        return Storage.Remove(binder.Name);
+    }
+}
+
+public class ThrowingDeleteDynamicObject : DynamicStorageObject
+{
+    public override bool TryDeleteMember(DeleteMemberBinder binder)
+        => throw new InvalidOperationException($"TryDeleteMember failed for '{binder.Name}'");
 }

--- a/src/testing/dlrtest.cs
+++ b/src/testing/dlrtest.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.Dynamic;
+
+namespace Python.Test;
+
+public class DynamicMappingObject : DynamicObject
+{
+    Dictionary<string, object> storage;
+
+    Dictionary<string, object> Storage => storage ??= [];
+
+    // Native members for testing that regular CLR access is unaffected.
+    public string Label = "default";
+    public int Multiplier { get; set; } = 1;
+    public int Multiply(int value) => value * Multiplier;
+
+    // Test helper: bypass normal member binding and write directly to dynamic storage.
+    public void SetDynamicValue(string name, object value) => Storage[name] = value;
+
+    // Test helper: retrieve the actual value stored in C# (for verification that None was stored as null)
+    public object GetDynamicValue(string name) => Storage.TryGetValue(name, out var value) ? value : null;
+
+
+
+    public override bool TryGetMember(GetMemberBinder binder, out object result)
+        => Storage.TryGetValue(binder.Name, out result);
+
+    public override bool TrySetMember(SetMemberBinder binder, object value)
+    {
+        Storage[binder.Name] = value;
+        return true;
+    }
+
+    public override bool TryDeleteMember(DeleteMemberBinder binder)
+        => binder is not null && Storage.Remove(binder.Name);
+
+    public override IEnumerable<string> GetDynamicMemberNames() => Storage.Keys;
+}

--- a/tests/test_dynamic.py
+++ b/tests/test_dynamic.py
@@ -1,0 +1,173 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+from System.Collections.Generic import Dictionary
+from System.Dynamic import ExpandoObject
+
+from Python.Test import DynamicMappingObject
+
+
+def _mro_names(obj):
+    return [f"{t.__module__}.{t.__name__}" for t in type(obj).__mro__]
+
+
+@pytest.mark.parametrize(
+    "obj, expected",
+    [
+        (DynamicMappingObject(), True),
+        (ExpandoObject(), True),
+        (Dictionary[str, int](), False),
+    ],
+)
+def test_dlr_mixin_presence(obj, expected):
+    has_mixin = "clr._extras.dlr.DynamicMetaObjectProviderMixin" in _mro_names(obj)
+    assert has_mixin is expected
+
+
+@pytest.mark.parametrize("obj", [DynamicMappingObject(), ExpandoObject()])
+def test_dynamic_binder(obj):
+    assert "answer" not in dir(obj)
+    assert "wrong_answer" not in dir(obj)
+	
+    setattr(obj, "answer", 42)
+    obj.wrong_answer = 54
+
+    assert obj.answer == 42
+    assert obj.wrong_answer == 54
+
+    assert "answer" in dir(obj)
+    assert "wrong_answer" in dir(obj)
+
+
+def test_native_members_are_accessible_and_keep_priority():
+    obj = DynamicMappingObject()
+    setattr(obj, "answer", 42)
+    obj.SetDynamicValue("Multiplier", 999)
+
+    # Native field
+    assert obj.Label == "default"
+    obj.Label = "changed"
+    assert obj.Label == "changed"
+
+    # Native property takes precedence over dynamic fallback
+    assert obj.Multiplier == 1
+    obj.Multiplier = 7
+    assert obj.Multiplier == 7
+
+    # Native method
+    obj.Multiplier = 3
+    assert obj.Multiply(5) == 15
+
+def test_dynamic_and_native_members_coexist():
+    obj = DynamicMappingObject()
+    setattr(obj, "answer", 42)
+    obj.Multiplier = 2
+    assert obj.answer == 42
+    assert obj.Multiplier == 2
+    assert obj.Multiply(10) == 20
+
+
+@pytest.mark.parametrize("obj", [DynamicMappingObject(), ExpandoObject()])
+def test_set_and_get_dynamic_property(obj):
+    """Test that setting and getting dynamic properties goes through DLR binder."""
+    # Get initial value (should be None for non-existent property)
+    assert not hasattr(obj, "MyProp")
+    
+    # Set a dynamic property to a value
+    obj.MyProp = 42
+    assert obj.MyProp == 42
+    
+    # Set to None and verify it stays None through DLR
+    obj.MyProp = None
+    assert obj.MyProp is None
+    
+    # Set to another value and verify
+    obj.MyProp = "hello"
+    assert obj.MyProp == "hello"
+
+
+def test_update_dynamic_value():
+    """Dynamic-only members should use DLR get/set/modify/delete end-to-end."""
+    obj = DynamicMappingObject()
+    assert not hasattr(obj, "DynamicOnly")
+
+    # Initial set should create a dynamic member
+    obj.DynamicOnly = "initial"
+    assert obj.DynamicOnly == "initial"
+
+    # Modify flows through TrySetMember
+    obj.DynamicOnly = "updated"
+    assert obj.DynamicOnly == "updated"
+
+    # Setting None keeps a present member with None value
+    obj.DynamicOnly = None
+    assert obj.DynamicOnly is None
+
+    # Delete flows through TryDeleteMember
+    del obj.DynamicOnly
+    assert "DynamicOnly" not in dir(obj)
+    assert not hasattr(obj, "DynamicOnly")
+
+
+def test_dynamic_set_none_updates_managed_store_after_get():
+    """Regression: get->set(None)->get must route through DLR and update managed storage."""
+    obj = DynamicMappingObject()
+    obj.SetDynamicValue("MyProp", "initial")
+
+    x = obj.MyProp
+    assert x == "initial"
+
+    obj.MyProp = None
+
+    y = obj.MyProp
+    assert y is None
+    assert obj.GetDynamicValue("MyProp") is None
+
+
+@pytest.mark.parametrize("obj", [DynamicMappingObject(), ExpandoObject()])
+def test_dynamic_member_lifecycle(obj):
+    """Dynamic members should support set/modify/get/delete via the DLR binder."""
+    name = "LifecycleMember"
+
+    assert not hasattr(obj, name)
+
+    setattr(obj, name, 1)
+    assert getattr(obj, name) == 1
+
+    setattr(obj, name, 2)
+    assert getattr(obj, name) == 2
+
+    delattr(obj, name)
+    assert not hasattr(obj, name)
+
+
+def test_derive_from_dynamic_class():
+    class MyMappingObject(DynamicMappingObject):
+        __namespace__ = "PythonNetTest"
+
+        def __init__(self):
+            self._custom = 0
+
+        @property
+        def custom_property(self):
+            return self._custom
+        
+        @custom_property.setter
+        def custom_property(self, i):
+            self._custom += i
+
+
+    obj = MyMappingObject()
+    with pytest.raises(AttributeError):
+        x = obj.unknown_property
+
+    assert obj.custom_property == 0
+
+    obj.custom_property = 5
+    assert obj.custom_property == 5
+
+    obj.custom_property = 5
+    assert obj.custom_property == 10
+
+    obj.other_property = None
+    assert obj.other_property is None

--- a/tests/test_dynamic.py
+++ b/tests/test_dynamic.py
@@ -8,6 +8,7 @@ from Python.Test import DynamicMappingObject
 from Python.Test import RejectingDeleteDynamicObject
 from Python.Test import RejectingSetDynamicObject
 from Python.Test import ThrowingDeleteDynamicObject
+from Python.Test import ThrowingGetDynamicObject
 from Python.Test import ThrowingSetDynamicObject
 
 
@@ -184,6 +185,14 @@ def test_trysetmember_false_raises_attributeerror_instead_of_silent_python_setat
         obj.typoed_name = 42
 
     assert not hasattr(obj, "typoed_name")
+
+
+def test_trygetmember_exception_is_raised_in_python():
+    obj = ThrowingGetDynamicObject()
+    obj.AddDynamicMember("any_key", 1)
+
+    with pytest.raises(Exception, match="TryGetMember failed for 'any_key'"):
+        _ = obj.any_key
 
 
 def test_trysetmember_exception_is_raised_in_python():

--- a/tests/test_dynamic.py
+++ b/tests/test_dynamic.py
@@ -5,6 +5,10 @@ from System.Collections.Generic import Dictionary
 from System.Dynamic import ExpandoObject
 
 from Python.Test import DynamicMappingObject
+from Python.Test import RejectingDeleteDynamicObject
+from Python.Test import RejectingSetDynamicObject
+from Python.Test import ThrowingDeleteDynamicObject
+from Python.Test import ThrowingSetDynamicObject
 
 
 def _mro_names(obj):
@@ -171,3 +175,35 @@ def test_derive_from_dynamic_class():
 
     obj.other_property = None
     assert obj.other_property is None
+
+
+def test_trysetmember_false_raises_attributeerror_instead_of_silent_python_setattr():
+    obj = RejectingSetDynamicObject()
+
+    with pytest.raises(AttributeError):
+        obj.typoed_name = 42
+
+    assert not hasattr(obj, "typoed_name")
+
+
+def test_trysetmember_exception_is_raised_in_python():
+    obj = ThrowingSetDynamicObject()
+
+    with pytest.raises(Exception, match="TrySetMember failed for 'bad_name'"):
+        obj.bad_name = 42
+
+
+def test_trydeletemember_false_raises_attributeerror():
+    obj = RejectingDeleteDynamicObject()
+    obj.AddDynamicMember("existing_name", 42)
+
+    with pytest.raises(AttributeError):
+        del obj.missing_name
+
+
+def test_trydeletemember_exception_is_raised_in_python():
+    obj = ThrowingDeleteDynamicObject()
+    obj.bad_name = 42
+
+    with pytest.raises(Exception, match="TryDeleteMember failed for 'bad_name'"):
+        del obj.bad_name


### PR DESCRIPTION
Cherry-picks from upstream `pythonnet/pythonnet` adding DLR get/set support so .NET `IDynamicMetaObjectProvider` objects (e.g. `dynamic`/ExpandoObject) expose their dynamic members to Python. `-x` cherry-picked (authorship preserved: Benedikt Reinartz, @greateggsgreg).

Commits:
- `c7990575` Implement support for DLR get/set (adds `DynamicObjectMemberAccessor`, `DynamicObjectMixinsProvider`, `Mixins/dlr.py`, `ConcurrentLruCache`, `tests/test_dynamic.py`)
- `4ff80820` Catch errors in setting/deleting properties
- `66ee8624` Propagate exceptions from `TryGetMember` in `tp_getattro_dlr_proxy` (pythonnet/pythonnet#2718)
- `f7e09a7b` Cache `HasClrMember` and align DLR setter exception path

Builds clean (`Python.Runtime.csproj` + `Python.EmbeddingTest.csproj`).

## ⚠️ Decision required — this re-enables the mixins providers (reverts #1785)
This feature is delivered through the **mixins mechanism**, which this fork **deliberately disabled** (the `// see pythonnet/pythonnet#1785` comment in `InteropConfiguration.cs`). To make DLR get/set work I had to **re-enable `CollectionMixinsProvider` and add `DynamicObjectMixinsProvider`** in `InteropConfiguration.cs`.

That means this PR effectively reverts the #1785 decision. **Please decide whether you want the mixins providers back on** — re-enabling `CollectionMixinsProvider` also restores the collection mixins (and the IDisposable context-manager from #119 would then work too). If #1785 was disabled for a real reason, that reason returns with this PR. CI on this PR will show whether re-enabling mixins breaks anything in the fork's suite.

Conflict resolution: `InteropConfiguration.cs` (re-enabled both providers), `TypeManager.cs` (kept upstream's try/catch setter path). Opening for your decision as requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)