### PR TITLE
Use a native __getattr__ hook for AttributeError suggestions (GIL-safe re-land of the miss-only hook)

### DIFF
--- a/src/runtime/AttributeErrorHint.cs
+++ b/src/runtime/AttributeErrorHint.cs
@@ -1,0 +1,109 @@
+using System;
+
+using Python.Runtime.Native;
+
+namespace Python.Runtime
+{
+    /// <summary>
+    /// Installs a miss-only <c>__getattr__</c> hook on reflected .NET types so that an
+    /// <c>AttributeError</c> raised for a missing attribute is enriched with suggestions
+    /// of similarly-named members — without adding any cost to the (common) successful
+    /// attribute-access path.
+    /// </summary>
+    /// <remarks>
+    /// CPython only invokes <c>__getattr__</c> after the normal attribute lookup fails,
+    /// via the native <c>slot_tp_getattr_hook</c>: on a hit it calls the generic getattr
+    /// directly (no managed transition); only on a miss does it call our <c>__getattr__</c>.
+    /// pythonnet's metatype does not run CPython's slot-fixup machinery when an attribute
+    /// is set on a type, so simply adding <c>__getattr__</c> to the type dict would not
+    /// rewire the slot — we therefore wire <c>tp_getattro</c> to the hook manually.
+    /// </remarks>
+    internal static class AttributeErrorHint
+    {
+        // The shared __getattr__ function object installed on every eligible type.
+        private static PyObject? _getAttr;
+        // The managed message builder exposed to Python, kept alive for _getAttr's globals.
+        private static PyObject? _messageBuilder;
+        // Address of CPython's slot_tp_getattr_hook (extracted from a probe type).
+        private static IntPtr _hookSlot;
+        // Address of PyObject_GenericGetAttr, used to detect types we may safely redirect.
+        private static IntPtr _genericGetAttr;
+
+        private static bool IsReady => _getAttr is not null && _hookSlot != IntPtr.Zero;
+
+        internal static void Initialize()
+        {
+            try
+            {
+                _genericGetAttr = Util.ReadIntPtr(Runtime.PyBaseObjectType, TypeOffset.tp_getattro);
+
+                Func<PyObject, string, string> builder = ClassBase.BuildMissingAttributeMessage;
+                _messageBuilder = builder.ToPython();
+
+                using var globals = new PyDict();
+                Runtime.PyDict_SetItemString(globals.Reference, "__builtins__", Runtime.PyEval_GetBuiltins());
+                globals["__clr_attr_msg__"] = _messageBuilder;
+
+                // Define the shared hook, plus a probe class whose tp_getattro is
+                // slot_tp_getattr_hook so we can read that function pointer.
+                PythonEngine.Exec(
+                    "def __clr_getattr__(self, name):\n" +
+                    "    raise AttributeError(__clr_attr_msg__(self, name))\n" +
+                    "class __clr_getattr_probe__:\n" +
+                    "    def __getattr__(self, name):\n" +
+                    "        raise AttributeError(name)\n",
+                    globals);
+
+                _getAttr = globals["__clr_getattr__"];
+                using var probe = globals["__clr_getattr_probe__"];
+                _hookSlot = Util.ReadIntPtr(probe.Reference, TypeOffset.tp_getattro);
+            }
+            catch (Exception e)
+            {
+                // Degrade gracefully: without the hook, AttributeError messages are simply
+                // not enriched. Never let this break interpreter initialization.
+                DebugUtil.Print($"AttributeErrorHint.Initialize failed: {e}");
+                Shutdown();
+            }
+        }
+
+        /// <summary>
+        /// Wires the miss-only hook onto <paramref name="type"/> if it still uses the
+        /// native generic getattr. Types with a custom <c>tp_getattro</c> (dynamic
+        /// objects, modules, interfaces, ...) handle misses themselves and are left
+        /// untouched; derived types that inherit an already-hooked base are likewise
+        /// skipped, since they inherit the behavior through the MRO.
+        /// </summary>
+        internal static void Install(BorrowedReference type)
+        {
+            if (!IsReady)
+            {
+                return;
+            }
+
+            if (Util.ReadIntPtr(type, TypeOffset.tp_getattro) != _genericGetAttr)
+            {
+                return;
+            }
+
+            if (Runtime.PyObject_SetAttrString(type, "__getattr__", _getAttr!.Reference) != 0)
+            {
+                Exceptions.Clear();
+                return;
+            }
+
+            Util.WriteIntPtr(type, TypeOffset.tp_getattro, _hookSlot);
+            Runtime.PyType_Modified(type);
+        }
+
+        internal static void Shutdown()
+        {
+            _getAttr?.Dispose();
+            _getAttr = null;
+            _messageBuilder?.Dispose();
+            _messageBuilder = null;
+            _hookSlot = IntPtr.Zero;
+            _genericGetAttr = IntPtr.Zero;
+        }
+    }
+}

--- a/src/runtime/AttributeErrorHint.cs
+++ b/src/runtime/AttributeErrorHint.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
 
 using Python.Runtime.Native;
 
@@ -17,19 +19,29 @@ namespace Python.Runtime
     /// pythonnet's metatype does not run CPython's slot-fixup machinery when an attribute
     /// is set on a type, so simply adding <c>__getattr__</c> to the type dict would not
     /// rewire the slot — we therefore wire <c>tp_getattro</c> to the hook manually.
+    ///
+    /// The <c>__getattr__</c> itself is a native method descriptor (PyDescr_NewMethod)
+    /// around a managed thunk, NOT a .NET delegate exposed to Python: delegate calls go
+    /// through <see cref="MethodBinder"/>, which releases the GIL around the invocation
+    /// (allow_threads), so the callback would run CPython C-API calls off-GIL and crash
+    /// whenever the <see cref="Finalizer"/> fires mid-callback. The native thunk is
+    /// called directly by the interpreter with the GIL held.
     /// </remarks>
     internal static class AttributeErrorHint
     {
-        // The shared __getattr__ function object installed on every eligible type.
-        private static PyObject? _getAttr;
-        // The managed message builder exposed to Python, kept alive for _getAttr's globals.
-        private static PyObject? _messageBuilder;
+        // Unmanaged PyMethodDef backing the shared __getattr__ method descriptors.
+        // Descriptors keep a raw pointer to it (d_method) and can outlive engine
+        // shutdown bookkeeping, so it is allocated once and kept for the process
+        // lifetime (as are the thunks in Interop.allocatedThunks).
+        private static IntPtr _methodDef;
+        // Keeps the thunk delegate for GetAttrHook alive.
+        private static ThunkInfo? _thunk;
         // Address of CPython's slot_tp_getattr_hook (extracted from a probe type).
         private static IntPtr _hookSlot;
         // Address of PyObject_GenericGetAttr, used to detect types we may safely redirect.
         private static IntPtr _genericGetAttr;
 
-        private static bool IsReady => _getAttr is not null && _hookSlot != IntPtr.Zero;
+        private static bool IsReady => _methodDef != IntPtr.Zero && _hookSlot != IntPtr.Zero;
 
         internal static void Initialize()
         {
@@ -37,24 +49,25 @@ namespace Python.Runtime
             {
                 _genericGetAttr = Util.ReadIntPtr(Runtime.PyBaseObjectType, TypeOffset.tp_getattro);
 
-                Func<PyObject, string, string> builder = ClassBase.BuildMissingAttributeMessage;
-                _messageBuilder = builder.ToPython();
+                if (_methodDef == IntPtr.Zero)
+                {
+                    _thunk = Interop.GetThunk(typeof(AttributeErrorHint).GetMethod(
+                        nameof(GetAttrHook), BindingFlags.Static | BindingFlags.Public)!);
+                    IntPtr methodDef = Marshal.AllocHGlobal(4 * IntPtr.Size);
+                    TypeManager.WriteMethodDef(methodDef, "__getattr__", _thunk.Address);
+                    _methodDef = methodDef;
+                }
 
+                // Define a probe class whose tp_getattro is slot_tp_getattr_hook so we
+                // can read that function pointer.
                 using var globals = new PyDict();
                 Runtime.PyDict_SetItemString(globals.Reference, "__builtins__", Runtime.PyEval_GetBuiltins());
-                globals["__clr_attr_msg__"] = _messageBuilder;
-
-                // Define the shared hook, plus a probe class whose tp_getattro is
-                // slot_tp_getattr_hook so we can read that function pointer.
                 PythonEngine.Exec(
-                    "def __clr_getattr__(self, name):\n" +
-                    "    raise AttributeError(__clr_attr_msg__(self, name))\n" +
                     "class __clr_getattr_probe__:\n" +
                     "    def __getattr__(self, name):\n" +
                     "        raise AttributeError(name)\n",
                     globals);
 
-                _getAttr = globals["__clr_getattr__"];
                 using var probe = globals["__clr_getattr_probe__"];
                 _hookSlot = Util.ReadIntPtr(probe.Reference, TypeOffset.tp_getattro);
             }
@@ -86,7 +99,15 @@ namespace Python.Runtime
                 return;
             }
 
-            if (Runtime.PyObject_SetAttrString(type, "__getattr__", _getAttr!.Reference) != 0)
+            using var descr = Runtime.PyDescr_NewMethod(type, _methodDef);
+            if (descr.IsNull())
+            {
+                Exceptions.Clear();
+                return;
+            }
+
+            BorrowedReference dict = Util.ReadRef(type, TypeOffset.tp_dict);
+            if (Runtime.PyDict_SetItemString(dict, "__getattr__", descr.Borrow()) != 0)
             {
                 Exceptions.Clear();
                 return;
@@ -96,12 +117,45 @@ namespace Python.Runtime
             Runtime.PyType_Modified(type);
         }
 
+        /// <summary>
+        /// The <c>__getattr__(self, name)</c> implementation (METH_VARARGS). CPython's
+        /// <c>slot_tp_getattr_hook</c> only calls it after the normal lookup has failed
+        /// and the original AttributeError has been cleared, so the full message is
+        /// rebuilt here. Runs as a direct native method call with the GIL held.
+        /// </summary>
+        public static NewReference GetAttrHook(BorrowedReference ob, BorrowedReference args)
+        {
+            string? name = null;
+            string message;
+            try
+            {
+                if (Runtime.PyTuple_Size(args) == 1)
+                {
+                    BorrowedReference key = Runtime.PyTuple_GetItem(args, 0);
+                    if (Runtime.PyString_Check(key))
+                    {
+                        name = Runtime.GetManagedString(key);
+                    }
+                }
+
+                using var self = new PyObject(ob);
+                message = ClassBase.BuildMissingAttributeMessage(self, name ?? "?");
+            }
+            catch
+            {
+                // Never let message building turn into a different exception.
+                message = $"object has no attribute '{name ?? "?"}'";
+            }
+
+            Exceptions.SetError(Exceptions.AttributeError, message);
+            return default;
+        }
+
         internal static void Shutdown()
         {
-            _getAttr?.Dispose();
-            _getAttr = null;
-            _messageBuilder?.Dispose();
-            _messageBuilder = null;
+            // _methodDef and _thunk are deliberately kept: method descriptors created
+            // from them may still be reachable during interpreter teardown, and both
+            // are reused by the next Initialize.
             _hookSlot = IntPtr.Zero;
             _genericGetAttr = IntPtr.Zero;
         }

--- a/src/runtime/PythonEngine.cs
+++ b/src/runtime/PythonEngine.cs
@@ -263,6 +263,10 @@ namespace Python.Runtime
             }
 
             ImportHook.UpdateCLRModuleDict();
+
+            // Set up the miss-only __getattr__ hook used to enrich AttributeError
+            // messages on reflected .NET types with member-name suggestions.
+            AttributeErrorHint.Initialize();
         }
 
         static BorrowedReference DefineModule(string name)
@@ -369,6 +373,9 @@ namespace Python.Runtime
             AppDomain.CurrentDomain.ProcessExit -= OnProcessExit;
 
             ExecuteShutdownHandlers();
+
+            AttributeErrorHint.Shutdown();
+
             // Remember to shut down the runtime.
             Runtime.Shutdown();
 

--- a/src/runtime/Runtime.Delegates.cs
+++ b/src/runtime/Runtime.Delegates.cs
@@ -230,6 +230,7 @@ public unsafe partial class Runtime
             PyObject_GenericGetAttr = (delegate* unmanaged[Cdecl]<BorrowedReference, BorrowedReference, NewReference>)GetFunctionByName(nameof(PyObject_GenericGetAttr), GetUnmanagedDll(_PythonDll));
             PyObject_GenericGetDict = (delegate* unmanaged[Cdecl]<BorrowedReference, IntPtr, NewReference>)GetFunctionByName(nameof(PyObject_GenericGetDict), GetUnmanagedDll(PythonDLL));
             PyObject_GenericSetAttr = (delegate* unmanaged[Cdecl]<BorrowedReference, BorrowedReference, BorrowedReference, int>)GetFunctionByName(nameof(PyObject_GenericSetAttr), GetUnmanagedDll(_PythonDll));
+            PyDescr_NewMethod = (delegate* unmanaged[Cdecl]<BorrowedReference, IntPtr, NewReference>)GetFunctionByName(nameof(PyDescr_NewMethod), GetUnmanagedDll(_PythonDll));
             PyObject_GC_Del = (delegate* unmanaged[Cdecl]<StolenReference, void>)GetFunctionByName(nameof(PyObject_GC_Del), GetUnmanagedDll(_PythonDll));
             try
             {
@@ -504,6 +505,7 @@ public unsafe partial class Runtime
         internal static delegate* unmanaged[Cdecl]<BorrowedReference, BorrowedReference, BorrowedReference> _PyType_Lookup { get; }
         internal static delegate* unmanaged[Cdecl]<BorrowedReference, BorrowedReference, NewReference> PyObject_GenericGetAttr { get; }
         internal static delegate* unmanaged[Cdecl]<BorrowedReference, BorrowedReference, BorrowedReference, int> PyObject_GenericSetAttr { get; }
+        internal static delegate* unmanaged[Cdecl]<BorrowedReference, IntPtr, NewReference> PyDescr_NewMethod { get; }
         internal static delegate* unmanaged[Cdecl]<StolenReference, void> PyObject_GC_Del { get; }
         internal static delegate* unmanaged[Cdecl]<BorrowedReference, int> PyObject_GC_IsTracked { get; }
         internal static delegate* unmanaged[Cdecl]<BorrowedReference, void> PyObject_GC_Track { get; }

--- a/src/runtime/Runtime.cs
+++ b/src/runtime/Runtime.cs
@@ -1738,6 +1738,13 @@ namespace Python.Runtime
 
         internal static int PyObject_GenericSetAttr(BorrowedReference obj, BorrowedReference name, BorrowedReference value) => Delegates.PyObject_GenericSetAttr(obj, name, value);
 
+
+        /// <summary>
+        /// Creates a method descriptor for <paramref name="type"/> from an unmanaged
+        /// <c>PyMethodDef*</c>, which must remain valid for the descriptor's lifetime.
+        /// </summary>
+        internal static NewReference PyDescr_NewMethod(BorrowedReference type, IntPtr methodDef) => Delegates.PyDescr_NewMethod(type, methodDef);
+
         internal static NewReference PyObject_GenericGetDict(BorrowedReference o) => PyObject_GenericGetDict(o, IntPtr.Zero);
         internal static NewReference PyObject_GenericGetDict(BorrowedReference o, IntPtr context) => Delegates.PyObject_GenericGetDict(o, context);
 

--- a/src/runtime/TypeManager.cs
+++ b/src/runtime/TypeManager.cs
@@ -303,6 +303,10 @@ namespace Python.Runtime
 
             Runtime.PyType_Modified(type.Reference);
 
+            // Enrich AttributeError messages for missing attributes with member-name
+            // suggestions, via a miss-only __getattr__ hook (no hot-path cost).
+            AttributeErrorHint.Install(type.Reference);
+
             //DebugUtil.DumpType(type);
         }
 

--- a/src/runtime/Types/ClassBase.cs
+++ b/src/runtime/Types/ClassBase.cs
@@ -628,20 +628,13 @@ namespace Python.Runtime
             }
 
             var name = Runtime.GetManagedString(key);
-            // Skip empty and dunder names: the latter are probed internally by CPython
-            // (e.g. __iter__, __len__) and are never user-facing typos worth helping with.
-            if (string.IsNullOrEmpty(name) || name.StartsWith("__", StringComparison.Ordinal))
+            if (string.IsNullOrEmpty(name))
             {
                 return;
             }
 
-            if (GetManagedObject(ob) is not CLRObject clrObj || clrObj.inst is null)
-            {
-                return;
-            }
-
-            var suggestions = GetSimilarMemberNames(clrObj.inst.GetType(), name);
-            if (suggestions.Count == 0)
+            var hint = GetSuggestionHint(ob, name);
+            if (hint.Length == 0)
             {
                 return;
             }
@@ -651,7 +644,6 @@ namespace Python.Runtime
             try
             {
                 var baseMessage = GetErrorMessage(errValue.BorrowNullable(), name);
-                var hint = " Did you mean: " + string.Join(", ", suggestions.Select(s => $"'{s}'")) + "?";
                 Exceptions.SetError(Exceptions.AttributeError, baseMessage + hint);
             }
             finally
@@ -660,6 +652,65 @@ namespace Python.Runtime
                 errValue.Dispose();
                 errTraceback.Dispose();
             }
+        }
+
+        /// <summary>
+        /// Builds the full message for an <c>AttributeError</c> raised for a missing
+        /// attribute on a .NET object, including any "Did you mean ...?" hint. Used by
+        /// the miss-only <c>__getattr__</c> hook installed on reflected types (see
+        /// <see cref="AttributeErrorHint"/>), where the original error has already been
+        /// cleared, so the base message is reconstructed here.
+        /// </summary>
+        internal static string BuildMissingAttributeMessage(PyObject self, string name)
+        {
+            var typeName = "object";
+            try
+            {
+                using var pyType = self.GetPythonType();
+                typeName = pyType.Name;
+            }
+            catch
+            {
+                // fall back to the generic type name
+            }
+
+            var message = $"'{typeName}' object has no attribute '{name}'";
+            try
+            {
+                return message + GetSuggestionHint(self.Reference, name);
+            }
+            catch
+            {
+                // never let suggestion building turn into a different exception
+                return message;
+            }
+        }
+
+        /// <summary>
+        /// Returns " Did you mean: 'x', 'y'?" listing similarly-named members of the
+        /// managed object, or an empty string when there is nothing to suggest. Dunder
+        /// names are skipped: they are probed internally by CPython (e.g. __iter__,
+        /// __len__) and are never user-facing typos worth helping with.
+        /// </summary>
+        private static string GetSuggestionHint(BorrowedReference ob, string name)
+        {
+            if (string.IsNullOrEmpty(name) || name.StartsWith("__", StringComparison.Ordinal))
+            {
+                return string.Empty;
+            }
+
+            if (GetManagedObject(ob) is not CLRObject clrObj || clrObj.inst is null)
+            {
+                return string.Empty;
+            }
+
+            var suggestions = GetSimilarMemberNames(clrObj.inst.GetType(), name);
+            if (suggestions.Count == 0)
+            {
+                return string.Empty;
+            }
+
+            return " Did you mean: " + string.Join(", ", suggestions.Select(s => $"'{s}'")) + "?";
         }
 
         private static string GetErrorMessage(BorrowedReference value, string fallbackName)

--- a/src/runtime/Types/ClassObject.cs
+++ b/src/runtime/Types/ClassObject.cs
@@ -167,21 +167,6 @@ namespace Python.Runtime
         protected virtual NewReference NewObjectToPython(object obj, BorrowedReference tp)
             => CLRObject.GetReference(obj, tp);
 
-        /// <summary>
-        /// Type __getattro__ implementation. Delegates to the generic CLR attribute
-        /// lookup, but enriches the AttributeError raised for a missing attribute with
-        /// suggestions of similarly-named members of the managed type.
-        /// </summary>
-        public static NewReference tp_getattro(BorrowedReference ob, BorrowedReference key)
-        {
-            var result = Runtime.PyObject_GenericGetAttr(ob, key);
-            if (result.IsNull())
-            {
-                AppendAttributeErrorSuggestions(ob, key);
-            }
-            return result;
-        }
-
         private static NewReference NewEnum(Type type, BorrowedReference args, BorrowedReference tp)
         {
             nint argCount = Runtime.PyTuple_Size(args);

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -104,6 +104,23 @@ def test_missing_attribute_hasattr_still_false():
     assert hasattr(s, "Length")
 
 
+def test_missing_attribute_hook_is_native():
+    """The __getattr__ hook must be a native method descriptor.
+
+    If it were a Python function calling into .NET through a delegate, the call
+    would go through MethodBinder, which releases the GIL around the invocation:
+    the hint-building callback would then run CPython C-API calls off-GIL and
+    crash whenever the pythonnet Finalizer fires mid-callback (the Lean CI crash
+    on 2.0.55).
+    """
+    hook = next(
+        c.__dict__["__getattr__"]
+        for c in type(System.String("x")).__mro__
+        if "__getattr__" in c.__dict__
+    )
+    assert type(hook).__name__ == "method_descriptor"
+
+
 def test_basic_subclass():
     """Test basic subclass of a managed class."""
     from System.Collections import Hashtable


### PR DESCRIPTION
### What does this implement/fix?

Re-lands the miss-only `__getattr__` hook for AttributeError member-name suggestions (the #124 approach, which #126 had replaced with a `tp_getattro` override), and fixes the off-GIL defect that crashed Lean's CI on 2.0.55.

**Why re-land the hook:** with the hook, successful attribute accesses go straight through CPython's native generic getattr with no managed transition — only an actual miss enters managed code. The #126 `tp_getattro` override put a managed round-trip on every attribute access, hit or miss.

**The 2.0.55 crash (see first commit):** the original hook exposed the hint builder to Python as a .NET delegate (`Func<PyObject, string, string>`). Python invoked it through `DelegateObject.tp_call` → `MethodBinder.Invoke`, and `MethodBinder` releases the GIL around every reflected invocation (`allow_threads` defaults to `true`). The callback therefore ran CPython C-API calls without holding the GIL on every attribute miss (`hasattr`, `getattr` with default, typos). It usually survived by luck, but segfaulted whenever the pythonnet `Finalizer` fired mid-callback: `Finalizer.DisposeAll()` starts with `PyErr_Fetch`, which dereferences the current thread state — NULL when the GIL is not held. This is what crashed Lean's CI test host after all 35k tests passed.

**The fix (second commit):** the `__getattr__` installed on reflected types is now a native method descriptor — a process-lifetime `PyMethodDef` (`METH_VARARGS`) around a managed thunk, created with `PyDescr_NewMethod` (newly bound in `Runtime.Delegates`). CPython's `slot_tp_getattr_hook` calls the managed hook directly as a native method call with the GIL held; `MethodBinder` is never involved.

User-facing messages are unchanged from 2.0.55/2.0.56:

```
AttributeError: 'Version' object has no attribute 'majr' Did you mean: 'major'?
```

### Does this close any currently open issues?

No open issue; this addresses the Lean CI test-host crash observed with 2.0.55 (`PyErr_Fetch(tstate=NULL)` under `Finalizer.DisposeAll` under `BuildMissingAttributeMessage`).

### Verification performed

- Instrumented build with `PyGILState_Check()` inside `BuildMissingAttributeMessage`: the delegate-based hook (first commit alone) reports `GIL held: False` on every miss; with the fix it reports `GIL held: True`.
- 20s stress run: 6 threads doing concurrent attribute misses + CLR object churn (to keep the Finalizer queue busy) — no crash.
- Embedding tests: 909 passed. Python tests: 443 passed (one pre-existing, environment-only failure from `quantconnect-stubs` shadowing the `Microsoft` namespace, identical on master).
- Lean's Python/Pandas unit tests run against this build with the test host surviving (the 2.0.55 failure mode was a host crash after tests passed).
- Behavioral checks: `hasattr`/`getattr`-with-default, dunder probes (pickle/copy machinery), Python subclasses defining their own `__getattr__`, and suggestions inherited by Python subclasses of .NET types all behave as before.

A new regression test (`test_missing_attribute_hook_is_native`) asserts the installed `__getattr__` is a native `method_descriptor`, the property that keeps the callback out of `MethodBinder`'s GIL-releasing path.
