### PR TITLE
Expose overload hint formatting as MethodSignatureFormatter and render Python-typed signatures

### DIFF
--- a/src/embed_tests/TestFloatToIntConversion.cs
+++ b/src/embed_tests/TestFloatToIntConversion.cs
@@ -100,9 +100,12 @@ def single_params(value):
         public void ErrorMessage_MultipleOverloads_ListsCandidates()
         {
             var ex = Assert.Throws<PythonException>(() => Call("overloaded_ctor", 5.5));
-            StringAssert.Contains("The following overloads are available:", ex.Message);
-            // The int overload is surfaced, hinting an integer was expected.
+            // The int overload is surfaced, hinting an integer was expected. The
+            // PyObject overload is skipped (it carries no type information), which
+            // leaves a single hinted signature here.
+            StringAssert.Contains("The expected signature is:", ex.Message);
             StringAssert.Contains("range: int", ex.Message);
+            StringAssert.DoesNotContain("volume_selector", ex.Message);
         }
 
         // The hinted signatures use the snake_case name Python callers use, not the

--- a/src/embed_tests/TestFloatToIntConversion.cs
+++ b/src/embed_tests/TestFloatToIntConversion.cs
@@ -93,7 +93,7 @@ def single_params(value):
         {
             var ex = Assert.Throws<PythonException>(() => Call("single_ctor", 5.5));
             StringAssert.Contains("The expected signature is:", ex.Message);
-            StringAssert.Contains("int value", ex.Message);
+            StringAssert.Contains("value: int", ex.Message);
         }
 
         [Test]
@@ -102,7 +102,7 @@ def single_params(value):
             var ex = Assert.Throws<PythonException>(() => Call("overloaded_ctor", 5.5));
             StringAssert.Contains("The following overloads are available:", ex.Message);
             // The int overload is surfaced, hinting an integer was expected.
-            StringAssert.Contains("int range", ex.Message);
+            StringAssert.Contains("range: int", ex.Message);
         }
 
         // The hinted signatures use the snake_case name Python callers use, not the

--- a/src/embed_tests/TestFloatToIntConversion.cs
+++ b/src/embed_tests/TestFloatToIntConversion.cs
@@ -93,7 +93,7 @@ def single_params(value):
         {
             var ex = Assert.Throws<PythonException>(() => Call("single_ctor", 5.5));
             StringAssert.Contains("The expected signature is:", ex.Message);
-            StringAssert.Contains("Int32 value", ex.Message);
+            StringAssert.Contains("int value", ex.Message);
         }
 
         [Test]
@@ -102,7 +102,7 @@ def single_params(value):
             var ex = Assert.Throws<PythonException>(() => Call("overloaded_ctor", 5.5));
             StringAssert.Contains("The following overloads are available:", ex.Message);
             // The int overload is surfaced, hinting an integer was expected.
-            StringAssert.Contains("Int32 range", ex.Message);
+            StringAssert.Contains("int range", ex.Message);
         }
 
         // The hinted signatures use the snake_case name Python callers use, not the

--- a/src/embed_tests/TestMethodSignatureFormatter.cs
+++ b/src/embed_tests/TestMethodSignatureFormatter.cs
@@ -80,6 +80,50 @@ namespace Python.EmbeddingTest
             Assert.AreEqual("SampleTarget(period: timedelta, start_time: Optional[timedelta] = None)", signature);
         }
 
+        [Test]
+        public void SkipsPyObjectOverloadsFromHints()
+        {
+            var hint = MethodSignatureFormatter.FormatOverloads(typeof(MixedOverloadsTarget).GetConstructors(),
+                displayName: nameof(MixedOverloadsTarget));
+
+            StringAssert.Contains("The following overloads are available:", hint);
+            StringAssert.Contains("MixedOverloadsTarget(period: timedelta)", hint);
+            StringAssert.Contains("MixedOverloadsTarget(max_count: int)", hint);
+            StringAssert.DoesNotContain("py_func", hint);
+        }
+
+        [Test]
+        public void ShowsPyObjectOverloadsWhenThereIsNothingElseToHint()
+        {
+            var hint = MethodSignatureFormatter.FormatOverloads(typeof(PyObjectOnlyTarget).GetConstructors(),
+                displayName: nameof(PyObjectOnlyTarget));
+
+            StringAssert.Contains("The expected signature is:", hint);
+            StringAssert.Contains("PyObjectOnlyTarget(py_func: Any)", hint);
+        }
+
+        private class MixedOverloadsTarget
+        {
+            public MixedOverloadsTarget(TimeSpan period)
+            {
+            }
+
+            public MixedOverloadsTarget(int maxCount)
+            {
+            }
+
+            public MixedOverloadsTarget(PyObject pyFunc)
+            {
+            }
+        }
+
+        private class PyObjectOnlyTarget
+        {
+            public PyObjectOnlyTarget(PyObject pyFunc)
+            {
+            }
+        }
+
         private class SampleTarget
         {
             public SampleTarget(TimeSpan period, TimeSpan? startTime = null)

--- a/src/embed_tests/TestMethodSignatureFormatter.cs
+++ b/src/embed_tests/TestMethodSignatureFormatter.cs
@@ -20,7 +20,7 @@ namespace Python.EmbeddingTest
         public void FormatsPrimitivesAsPythonTypes()
         {
             Assert.AreEqual(
-                "primitives(int count, float price, float ratio, float scale, bool flag, str name, str letter)",
+                "primitives(count: int, price: float, ratio: float, scale: float, flag: bool, name: str, letter: str)",
                 SignatureOf(nameof(SampleTarget.Primitives)));
         }
 
@@ -28,7 +28,7 @@ namespace Python.EmbeddingTest
         public void FormatsTimeTypesAsDatetimeAndTimedelta()
         {
             Assert.AreEqual(
-                "time_types(datetime time, timedelta period)",
+                "time_types(time: datetime, period: timedelta)",
                 SignatureOf(nameof(SampleTarget.TimeTypes)));
         }
 
@@ -36,7 +36,7 @@ namespace Python.EmbeddingTest
         public void FormatsNullablesAsOptional()
         {
             Assert.AreEqual(
-                "nullables(Optional[timedelta] start_time = None, Optional[int] max_count = None)",
+                "nullables(start_time: Optional[timedelta] = None, max_count: Optional[int] = None)",
                 SignatureOf(nameof(SampleTarget.Nullables)));
         }
 
@@ -44,7 +44,7 @@ namespace Python.EmbeddingTest
         public void FormatsDelegatesAsCallable()
         {
             Assert.AreEqual(
-                "delegates(Callable[[datetime], int] selector, Callable[[str], None] handler)",
+                "delegates(selector: Callable[[datetime], int], handler: Callable[[str], None])",
                 SignatureOf(nameof(SampleTarget.Delegates)));
         }
 
@@ -52,7 +52,7 @@ namespace Python.EmbeddingTest
         public void FormatsCollectionsAsListAndDict()
         {
             Assert.AreEqual(
-                "collections(List[str] names, List[int] values, List[float] prices, Dict[str, float] lookup)",
+                "collections(names: List[str], values: List[int], prices: List[float], lookup: Dict[str, float])",
                 SignatureOf(nameof(SampleTarget.Collections)));
         }
 
@@ -60,7 +60,7 @@ namespace Python.EmbeddingTest
         public void FormatsObjectAndPyObjectAsAny()
         {
             Assert.AreEqual(
-                "any_types(Any anything, Any py_object, List[Any] py_list, Dict[Any, Any] py_dict)",
+                "any_types(anything: Any, py_object: Any, py_list: List[Any], py_dict: Dict[Any, Any])",
                 SignatureOf(nameof(SampleTarget.AnyTypes)));
         }
 
@@ -68,7 +68,7 @@ namespace Python.EmbeddingTest
         public void KeepsClrOnlyTypeNames()
         {
             Assert.AreEqual(
-                "clr_types(Uri address, StringComparison mode = StringComparison.ORDINAL)",
+                "clr_types(address: Uri, mode: StringComparison = StringComparison.ORDINAL)",
                 SignatureOf(nameof(SampleTarget.ClrTypes)));
         }
 
@@ -77,7 +77,7 @@ namespace Python.EmbeddingTest
         {
             var signature = MethodSignatureFormatter.FormatSignature(
                 typeof(SampleTarget).GetConstructors()[0], nameof(SampleTarget));
-            Assert.AreEqual("SampleTarget(timedelta period, Optional[timedelta] start_time = None)", signature);
+            Assert.AreEqual("SampleTarget(period: timedelta, start_time: Optional[timedelta] = None)", signature);
         }
 
         private class SampleTarget

--- a/src/embed_tests/TestMethodSignatureFormatter.cs
+++ b/src/embed_tests/TestMethodSignatureFormatter.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Python.Runtime;
+
+namespace Python.EmbeddingTest
+{
+    /// <summary>
+    /// The overload hint signatures must show the Python types a caller uses,
+    /// following the conversions the runtime performs on arguments.
+    /// </summary>
+    public class TestMethodSignatureFormatter
+    {
+        private static string SignatureOf(string methodName, string displayName = null)
+        {
+            return MethodSignatureFormatter.FormatSignature(typeof(SampleTarget).GetMethod(methodName), displayName);
+        }
+
+        [Test]
+        public void FormatsPrimitivesAsPythonTypes()
+        {
+            Assert.AreEqual(
+                "primitives(int count, float price, float ratio, float scale, bool flag, str name, str letter)",
+                SignatureOf(nameof(SampleTarget.Primitives)));
+        }
+
+        [Test]
+        public void FormatsTimeTypesAsDatetimeAndTimedelta()
+        {
+            Assert.AreEqual(
+                "time_types(datetime time, timedelta period)",
+                SignatureOf(nameof(SampleTarget.TimeTypes)));
+        }
+
+        [Test]
+        public void FormatsNullablesAsOptional()
+        {
+            Assert.AreEqual(
+                "nullables(Optional[timedelta] start_time = None, Optional[int] max_count = None)",
+                SignatureOf(nameof(SampleTarget.Nullables)));
+        }
+
+        [Test]
+        public void FormatsDelegatesAsCallable()
+        {
+            Assert.AreEqual(
+                "delegates(Callable[[datetime], int] selector, Callable[[str], None] handler)",
+                SignatureOf(nameof(SampleTarget.Delegates)));
+        }
+
+        [Test]
+        public void FormatsCollectionsAsListAndDict()
+        {
+            Assert.AreEqual(
+                "collections(List[str] names, List[int] values, List[float] prices, Dict[str, float] lookup)",
+                SignatureOf(nameof(SampleTarget.Collections)));
+        }
+
+        [Test]
+        public void FormatsObjectAndPyObjectAsAny()
+        {
+            Assert.AreEqual(
+                "any_types(Any anything, Any py_object, List[Any] py_list, Dict[Any, Any] py_dict)",
+                SignatureOf(nameof(SampleTarget.AnyTypes)));
+        }
+
+        [Test]
+        public void KeepsClrOnlyTypeNames()
+        {
+            Assert.AreEqual(
+                "clr_types(Uri address, StringComparison mode = StringComparison.ORDINAL)",
+                SignatureOf(nameof(SampleTarget.ClrTypes)));
+        }
+
+        [Test]
+        public void RendersConstructorsWithDisplayName()
+        {
+            var signature = MethodSignatureFormatter.FormatSignature(
+                typeof(SampleTarget).GetConstructors()[0], nameof(SampleTarget));
+            Assert.AreEqual("SampleTarget(timedelta period, Optional[timedelta] start_time = None)", signature);
+        }
+
+        private class SampleTarget
+        {
+            public SampleTarget(TimeSpan period, TimeSpan? startTime = null)
+            {
+            }
+
+            public void Primitives(int count, double price, decimal ratio, float scale, bool flag, string name, char letter)
+            {
+            }
+
+            public void TimeTypes(DateTime time, TimeSpan period)
+            {
+            }
+
+            public void Nullables(TimeSpan? startTime = null, int? maxCount = null)
+            {
+            }
+
+            public void Delegates(Func<DateTime, int> selector, Action<string> handler)
+            {
+            }
+
+            public void Collections(List<string> names, IEnumerable<int> values, decimal[] prices, Dictionary<string, decimal> lookup)
+            {
+            }
+
+            public void AnyTypes(object anything, PyObject pyObject, PyList pyList, PyDict pyDict)
+            {
+            }
+
+            public void ClrTypes(Uri address, StringComparison mode = StringComparison.Ordinal)
+            {
+            }
+        }
+    }
+}

--- a/src/runtime/MethodBinder.cs
+++ b/src/runtime/MethodBinder.cs
@@ -1012,11 +1012,11 @@ namespace Python.Runtime
                     // Use the snake_case name Python callers use, matching the hinted signatures below.
                     if (methodinfo != null && methodinfo.Length > 0)
                     {
-                        value.Append($" for {SnakeCaseName(methodinfo[0])}");
+                        value.Append($" for {MethodSignatureFormatter.SnakeCaseName(methodinfo[0])}");
                     }
                     else if (list.Count > 0)
                     {
-                        value.Append($" for {SnakeCaseName(list[0].MethodBase)}");
+                        value.Append($" for {MethodSignatureFormatter.SnakeCaseName(list[0].MethodBase)}");
                     }
 
                     value.Append(": ");
@@ -1028,7 +1028,11 @@ namespace Python.Runtime
                     var candidates = methodinfo != null && methodinfo.Length > 0
                         ? methodinfo.Cast<MethodBase>()
                         : list?.Select(m => m.MethodBase);
-                    AppendOverloads(value, candidates);
+                    var overloads = MethodSignatureFormatter.FormatOverloads(candidates);
+                    if (overloads.Length > 0)
+                    {
+                        value.Append(". ").Append(overloads);
+                    }
 
                     Exceptions.RaiseTypeError(value.ToString());
                 }
@@ -1235,147 +1239,6 @@ namespace Python.Runtime
             to.Append(')');
         }
 
-        /// <summary>
-        /// Appends the signatures of the candidate overloads to the given error
-        /// message, so a failed bind hints the caller at what the method expects.
-        /// </summary>
-        private static void AppendOverloads(StringBuilder to, IEnumerable<MethodBase> methods)
-        {
-            if (methods == null)
-            {
-                return;
-            }
-
-            // Building this only runs on the error path; never let it throw and mask
-            // the original binding failure.
-            try
-            {
-                // Distinct signatures, preserving order. Snake-cased duplicates and
-                // repeated overloads collapse into a single entry.
-                var signatures = new List<string>();
-                var seen = new HashSet<string>();
-                foreach (var method in methods)
-                {
-                    if (method == null)
-                    {
-                        continue;
-                    }
-                    var signature = FormatSignature(method);
-                    if (seen.Add(signature))
-                    {
-                        signatures.Add(signature);
-                    }
-                }
-
-                if (signatures.Count == 0)
-                {
-                    return;
-                }
-
-                const int maxShown = 10;
-                to.Append(signatures.Count == 1
-                    ? ". The expected signature is:"
-                    : ". The following overloads are available:");
-                for (var i = 0; i < signatures.Count && i < maxShown; i++)
-                {
-                    to.Append("\n  ").Append(signatures[i]);
-                }
-                if (signatures.Count > maxShown)
-                {
-                    to.Append($"\n  ... and {signatures.Count - maxShown} more");
-                }
-            }
-            catch
-            {
-                // Best-effort hint only.
-            }
-        }
-
-        /// <summary>
-        /// Formats a method/constructor as a readable signature using the snake_case
-        /// name Python callers use, e.g.
-        /// <c>range_consolidator(Int32 range, Func[IBaseData, Decimal] selector = None)</c>.
-        /// The constructor's special <c>.ctor</c> token is left as-is.
-        /// </summary>
-        private static string FormatSignature(MethodBase method)
-        {
-            var to = new StringBuilder();
-            to.Append(SnakeCaseName(method)).Append('(');
-            var parameters = method.GetParameters();
-            for (var i = 0; i < parameters.Length; i++)
-            {
-                if (i > 0)
-                {
-                    to.Append(", ");
-                }
-                var parameter = parameters[i];
-                if (parameter.IsDefined(typeof(ParamArrayAttribute), false))
-                {
-                    to.Append("params ");
-                }
-                to.Append(FormatType(parameter.ParameterType)).Append(' ').Append(parameter.Name.ToSnakeCase());
-                if (parameter.IsOptional)
-                {
-                    to.Append(" = ").Append(FormatDefaultValue(parameter.DefaultValue));
-                }
-            }
-            to.Append(')');
-            return to.ToString();
-        }
-
-        /// <summary>
-        /// Produces a concise, readable name for a CLR type, unwrapping by-ref and
-        /// nullable types and rendering generics as <c>Name[Arg1, Arg2]</c>.
-        /// </summary>
-        private static string FormatType(Type type)
-        {
-            if (type.IsByRef)
-            {
-                type = type.GetElementType();
-            }
-
-            var underlying = Nullable.GetUnderlyingType(type);
-            if (underlying != null)
-            {
-                return FormatType(underlying) + "?";
-            }
-
-            if (type.IsGenericType)
-            {
-                var name = type.Name;
-                var tick = name.IndexOf('`');
-                if (tick >= 0)
-                {
-                    name = name.Substring(0, tick);
-                }
-                var args = type.GetGenericArguments().Select(FormatType);
-                return $"{name}[{string.Join(", ", args)}]";
-            }
-
-            return type.Name;
-        }
-
-        /// <summary>
-        /// The snake_case name a Python caller uses for the given method. Constructors
-        /// keep their special <c>.ctor</c> token (a Python caller invokes the type).
-        /// </summary>
-        private static string SnakeCaseName(MethodBase method)
-        {
-            return method.IsConstructor ? method.Name : method.Name.ToSnakeCase();
-        }
-
-        private static string FormatDefaultValue(object value)
-        {
-            if (value == null || value is DBNull)
-            {
-                return "None";
-            }
-            if (value is string s)
-            {
-                return $"\"{s}\"";
-            }
-            return value.ToString();
-        }
     }
 
 

--- a/src/runtime/MethodSignatureFormatter.cs
+++ b/src/runtime/MethodSignatureFormatter.cs
@@ -77,9 +77,9 @@ namespace Python.Runtime
         }
 
         /// <summary>
-        /// Formats a method/constructor as a readable signature using the snake_case
-        /// name and the Python types a Python caller uses, e.g.
-        /// <c>range_consolidator(int range, Callable[[IBaseData], float] selector = None)</c>.
+        /// Formats a method/constructor as a Python signature: snake_case name and
+        /// parameters annotated with the Python types a Python caller uses, e.g.
+        /// <c>range_consolidator(range: int, selector: Callable[[IBaseData], float] = None)</c>.
         /// The constructor's special <c>.ctor</c> token is left as-is unless
         /// <paramref name="displayName"/> is provided.
         /// </summary>
@@ -97,9 +97,14 @@ namespace Python.Runtime
                 var parameter = parameters[i];
                 if (parameter.IsDefined(typeof(ParamArrayAttribute), false))
                 {
-                    to.Append("params ");
+                    // Python variadic form; annotate with the element type
+                    var elementType = parameter.ParameterType.IsArray
+                        ? parameter.ParameterType.GetElementType()
+                        : parameter.ParameterType;
+                    to.Append('*').Append(parameter.Name.ToSnakeCase()).Append(": ").Append(FormatType(elementType));
+                    continue;
                 }
-                to.Append(FormatType(parameter.ParameterType)).Append(' ').Append(parameter.Name.ToSnakeCase());
+                to.Append(parameter.Name.ToSnakeCase()).Append(": ").Append(FormatType(parameter.ParameterType));
                 if (parameter.IsOptional)
                 {
                     to.Append(" = ").Append(FormatDefaultValue(parameter.DefaultValue));

--- a/src/runtime/MethodSignatureFormatter.cs
+++ b/src/runtime/MethodSignatureFormatter.cs
@@ -8,7 +8,7 @@ namespace Python.Runtime
 {
     /// <summary>
     /// Formats method and constructor signatures the way Python callers see them
-    /// (snake_case names, friendly type names). Used to hint the available overloads
+    /// (snake_case names, Python type names). Used to hint the available overloads
     /// in error messages when a call cannot be matched to any of them.
     /// </summary>
     public static class MethodSignatureFormatter
@@ -78,8 +78,8 @@ namespace Python.Runtime
 
         /// <summary>
         /// Formats a method/constructor as a readable signature using the snake_case
-        /// name Python callers use, e.g.
-        /// <c>range_consolidator(Int32 range, Func[IBaseData, Decimal] selector = None)</c>.
+        /// name and the Python types a Python caller uses, e.g.
+        /// <c>range_consolidator(int range, Callable[[IBaseData], float] selector = None)</c>.
         /// The constructor's special <c>.ctor</c> token is left as-is unless
         /// <paramref name="displayName"/> is provided.
         /// </summary>
@@ -119,8 +119,12 @@ namespace Python.Runtime
         }
 
         /// <summary>
-        /// Produces a concise, readable name for a CLR type, unwrapping by-ref and
-        /// nullable types and rendering generics as <c>Name[Arg1, Arg2]</c>.
+        /// Produces the Python-side name for a CLR type, following the conversions the
+        /// runtime performs on arguments: primitives map to their Python equivalents
+        /// (str, int, float, bool, datetime, timedelta), Nullable to Optional, delegates
+        /// to Callable, list/dictionary shapes to List/Dict and PyObject/object to Any.
+        /// CLR types without a Python equivalent keep their name, with generics rendered
+        /// as <c>Name[Arg1, Arg2]</c>.
         /// </summary>
         private static string FormatType(Type type)
         {
@@ -132,18 +136,108 @@ namespace Python.Runtime
             var underlying = Nullable.GetUnderlyingType(type);
             if (underlying != null)
             {
-                return FormatType(underlying) + "?";
+                return $"Optional[{FormatType(underlying)}]";
+            }
+
+            if (type == typeof(void))
+            {
+                return "None";
+            }
+            if (type == typeof(TimeSpan))
+            {
+                return "timedelta";
+            }
+            if (type == typeof(object))
+            {
+                return "Any";
+            }
+            if (typeof(Type).IsAssignableFrom(type))
+            {
+                return "type";
+            }
+
+            // pythonnet wrapper parameters accept any Python object of the matching shape
+            if (type == typeof(PyList))
+            {
+                return "List[Any]";
+            }
+            if (type == typeof(PyDict))
+            {
+                return "Dict[Any, Any]";
+            }
+            if (typeof(PyObject).IsAssignableFrom(type))
+            {
+                return "Any";
+            }
+
+            if (type.IsArray)
+            {
+                return $"List[{FormatType(type.GetElementType())}]";
+            }
+
+            if (typeof(Delegate).IsAssignableFrom(type) && !type.ContainsGenericParameters)
+            {
+                var invoke = type.GetMethod("Invoke");
+                if (invoke != null)
+                {
+                    var args = string.Join(", ", invoke.GetParameters().Select(p => FormatType(p.ParameterType)));
+                    return $"Callable[[{args}], {FormatType(invoke.ReturnType)}]";
+                }
+            }
+
+            // Enums have an integer type code but keep their Python-visible name
+            if (!type.IsEnum)
+            {
+                switch (Type.GetTypeCode(type))
+                {
+                    case TypeCode.Boolean:
+                        return "bool";
+                    case TypeCode.Char:
+                    case TypeCode.String:
+                        return "str";
+                    case TypeCode.SByte:
+                    case TypeCode.Byte:
+                    case TypeCode.Int16:
+                    case TypeCode.UInt16:
+                    case TypeCode.Int32:
+                    case TypeCode.UInt32:
+                    case TypeCode.Int64:
+                    case TypeCode.UInt64:
+                        return "int";
+                    case TypeCode.Single:
+                    case TypeCode.Double:
+                    case TypeCode.Decimal:
+                        return "float";
+                    case TypeCode.DateTime:
+                        return "datetime";
+                }
             }
 
             if (type.IsGenericType)
             {
+                var definition = type.GetGenericTypeDefinition();
+                var genericArguments = type.GetGenericArguments();
+
+                // list and dictionary shapes the runtime converts from Python lists/dicts
+                if (definition == typeof(List<>) || definition == typeof(IList<>) ||
+                    definition == typeof(IEnumerable<>) || definition == typeof(ICollection<>) ||
+                    definition == typeof(IReadOnlyList<>) || definition == typeof(IReadOnlyCollection<>))
+                {
+                    return $"List[{FormatType(genericArguments[0])}]";
+                }
+                if (definition == typeof(Dictionary<,>) || definition == typeof(IDictionary<,>) ||
+                    definition == typeof(IReadOnlyDictionary<,>) || definition == typeof(KeyValuePair<,>))
+                {
+                    return $"Dict[{FormatType(genericArguments[0])}, {FormatType(genericArguments[1])}]";
+                }
+
                 var name = type.Name;
                 var tick = name.IndexOf('`');
                 if (tick >= 0)
                 {
                     name = name.Substring(0, tick);
                 }
-                var args = type.GetGenericArguments().Select(FormatType);
+                var args = genericArguments.Select(FormatType);
                 return $"{name}[{string.Join(", ", args)}]";
             }
 
@@ -159,6 +253,15 @@ namespace Python.Runtime
             if (value is string s)
             {
                 return $"\"{s}\"";
+            }
+            if (value is bool b)
+            {
+                return b ? "True" : "False";
+            }
+            if (value is Enum e)
+            {
+                // Render enum defaults the way Python callers access them, e.g. Resolution.DAILY
+                return $"{e.GetType().Name}.{e.ToString().ToSnakeCase(constant: true)}";
             }
             return value.ToString();
         }

--- a/src/runtime/MethodSignatureFormatter.cs
+++ b/src/runtime/MethodSignatureFormatter.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace Python.Runtime
+{
+    /// <summary>
+    /// Formats method and constructor signatures the way Python callers see them
+    /// (snake_case names, friendly type names). Used to hint the available overloads
+    /// in error messages when a call cannot be matched to any of them.
+    /// </summary>
+    public static class MethodSignatureFormatter
+    {
+        /// <summary>
+        /// Formats the signatures of the candidate overloads as an error message hint,
+        /// so the caller can see what the method expects, e.g.
+        /// "The following overloads are available:" followed by one signature per line.
+        /// Returns an empty string if there are no signatures to show.
+        /// </summary>
+        /// <param name="methods">The candidate overloads</param>
+        /// <param name="maxShown">The maximum number of signatures to include</param>
+        /// <param name="displayName">Optional name to display for the methods, e.g. the type
+        /// name for constructors instead of the special <c>.ctor</c> token</param>
+        public static string FormatOverloads(IEnumerable<MethodBase> methods, int maxShown = 10, string displayName = null)
+        {
+            if (methods == null)
+            {
+                return string.Empty;
+            }
+
+            // Building this only runs on error paths; never let it throw and mask
+            // the original failure.
+            try
+            {
+                // Distinct signatures, preserving order. Snake-cased duplicates and
+                // repeated overloads collapse into a single entry.
+                var signatures = new List<string>();
+                var seen = new HashSet<string>();
+                foreach (var method in methods)
+                {
+                    if (method == null)
+                    {
+                        continue;
+                    }
+                    var signature = FormatSignature(method, displayName);
+                    if (seen.Add(signature))
+                    {
+                        signatures.Add(signature);
+                    }
+                }
+
+                if (signatures.Count == 0)
+                {
+                    return string.Empty;
+                }
+
+                var to = new StringBuilder(signatures.Count == 1
+                    ? "The expected signature is:"
+                    : "The following overloads are available:");
+                for (var i = 0; i < signatures.Count && i < maxShown; i++)
+                {
+                    to.Append("\n  ").Append(signatures[i]);
+                }
+                if (signatures.Count > maxShown)
+                {
+                    to.Append($"\n  ... and {signatures.Count - maxShown} more");
+                }
+                return to.ToString();
+            }
+            catch
+            {
+                // Best-effort hint only.
+                return string.Empty;
+            }
+        }
+
+        /// <summary>
+        /// Formats a method/constructor as a readable signature using the snake_case
+        /// name Python callers use, e.g.
+        /// <c>range_consolidator(Int32 range, Func[IBaseData, Decimal] selector = None)</c>.
+        /// The constructor's special <c>.ctor</c> token is left as-is unless
+        /// <paramref name="displayName"/> is provided.
+        /// </summary>
+        public static string FormatSignature(MethodBase method, string displayName = null)
+        {
+            var to = new StringBuilder();
+            to.Append(displayName ?? SnakeCaseName(method)).Append('(');
+            var parameters = method.GetParameters();
+            for (var i = 0; i < parameters.Length; i++)
+            {
+                if (i > 0)
+                {
+                    to.Append(", ");
+                }
+                var parameter = parameters[i];
+                if (parameter.IsDefined(typeof(ParamArrayAttribute), false))
+                {
+                    to.Append("params ");
+                }
+                to.Append(FormatType(parameter.ParameterType)).Append(' ').Append(parameter.Name.ToSnakeCase());
+                if (parameter.IsOptional)
+                {
+                    to.Append(" = ").Append(FormatDefaultValue(parameter.DefaultValue));
+                }
+            }
+            to.Append(')');
+            return to.ToString();
+        }
+
+        /// <summary>
+        /// The snake_case name a Python caller uses for the given method. Constructors
+        /// keep their special <c>.ctor</c> token (a Python caller invokes the type).
+        /// </summary>
+        internal static string SnakeCaseName(MethodBase method)
+        {
+            return method.IsConstructor ? method.Name : method.Name.ToSnakeCase();
+        }
+
+        /// <summary>
+        /// Produces a concise, readable name for a CLR type, unwrapping by-ref and
+        /// nullable types and rendering generics as <c>Name[Arg1, Arg2]</c>.
+        /// </summary>
+        private static string FormatType(Type type)
+        {
+            if (type.IsByRef)
+            {
+                type = type.GetElementType();
+            }
+
+            var underlying = Nullable.GetUnderlyingType(type);
+            if (underlying != null)
+            {
+                return FormatType(underlying) + "?";
+            }
+
+            if (type.IsGenericType)
+            {
+                var name = type.Name;
+                var tick = name.IndexOf('`');
+                if (tick >= 0)
+                {
+                    name = name.Substring(0, tick);
+                }
+                var args = type.GetGenericArguments().Select(FormatType);
+                return $"{name}[{string.Join(", ", args)}]";
+            }
+
+            return type.Name;
+        }
+
+        private static string FormatDefaultValue(object value)
+        {
+            if (value == null || value is DBNull)
+            {
+                return "None";
+            }
+            if (value is string s)
+            {
+                return $"\"{s}\"";
+            }
+            return value.ToString();
+        }
+    }
+}

--- a/src/runtime/MethodSignatureFormatter.cs
+++ b/src/runtime/MethodSignatureFormatter.cs
@@ -17,6 +17,10 @@ namespace Python.Runtime
         /// Formats the signatures of the candidate overloads as an error message hint,
         /// so the caller can see what the method expects, e.g.
         /// "The following overloads are available:" followed by one signature per line.
+        /// Overloads taking PyObject parameters are skipped: they accept any Python
+        /// object and carry no type information (they are typically the overloads that
+        /// just rejected the value). If every candidate takes a PyObject, they are shown
+        /// anyway rather than producing no hint at all.
         /// Returns an empty string if there are no signatures to show.
         /// </summary>
         /// <param name="methods">The candidate overloads</param>
@@ -34,16 +38,19 @@ namespace Python.Runtime
             // the original failure.
             try
             {
+                var candidates = methods.Where(method => method != null).ToList();
+                var withoutPyObject = candidates.Where(method => !TakesPyObject(method)).ToList();
+                if (withoutPyObject.Count > 0)
+                {
+                    candidates = withoutPyObject;
+                }
+
                 // Distinct signatures, preserving order. Snake-cased duplicates and
                 // repeated overloads collapse into a single entry.
                 var signatures = new List<string>();
                 var seen = new HashSet<string>();
-                foreach (var method in methods)
+                foreach (var method in candidates)
                 {
-                    if (method == null)
-                    {
-                        continue;
-                    }
                     var signature = FormatSignature(method, displayName);
                     if (seen.Add(signature))
                     {
@@ -121,6 +128,22 @@ namespace Python.Runtime
         internal static string SnakeCaseName(MethodBase method)
         {
             return method.IsConstructor ? method.Name : method.Name.ToSnakeCase();
+        }
+
+        /// <summary>
+        /// Determines whether any of the method's parameters is a PyObject
+        /// </summary>
+        private static bool TakesPyObject(MethodBase method)
+        {
+            return method.GetParameters().Any(parameter =>
+            {
+                var type = parameter.ParameterType;
+                if (type.IsByRef)
+                {
+                    type = type.GetElementType();
+                }
+                return typeof(PyObject).IsAssignableFrom(type);
+            });
         }
 
         /// <summary>


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Two related improvements to the overload hints added in #128:

**1. Extract the hint logic into a public `MethodSignatureFormatter`** (`AppendOverloads`, `FormatSignature`, `FormatType`, `SnakeCaseName`, `FormatDefaultValue` move out of `MethodBinder`) so it can be reused outside the binder. Downstream consumers (e.g. Lean) can now append the same "The following overloads are available:" hint to their own user-facing error messages when they reject a `PyObject` argument themselves (see the argument validation improvements in QuantConnect/Lean#9607, where e.g. `QuoteBarConsolidator(Resolution.DAILY)` now lists the consolidator's constructor overloads).

Public API:

- `MethodSignatureFormatter.FormatOverloads(IEnumerable<MethodBase> methods, int maxShown = 10, string displayName = null)` — returns the hint text (`The expected signature is:` / `The following overloads are available:` followed by one signature per line, distinct and capped), or an empty string. Still best-effort: it never throws.
- `MethodSignatureFormatter.FormatSignature(MethodBase method, string displayName = null)` — the snake_case signature renderer; the optional `displayName` lets constructors be rendered with the type name instead of the special `.ctor` token (useful for consumer messages; the binder keeps `.ctor`).

**2. Render the hinted signatures as Python signatures** — parameters as `name: type` annotations (`*name: type` for `params` arrays), with Python types instead of C# type names, following the conversions the runtime actually performs on arguments:

- `str`/`int`/`float`/`bool` for strings, chars and numeric primitives
- `datetime` / `timedelta` for `DateTime` / `TimeSpan`
- `Optional[T]` for `Nullable<T>`
- `Callable[[args], ret]` for delegates (`None` return for actions)
- `List[T]` / `Dict[K, V]` for arrays, list and dictionary shapes
- `Any` for `object` and `PyObject` (`List[Any]`/`Dict[Any, Any]` for `PyList`/`PyDict`)
- CLR-only types (enums, classes) keep their Python-visible name
- Enum defaults rendered as Python callers access them (e.g. `StringComparison.ORDINAL`), bool defaults as `True`/`False`

Additionally, overloads taking `PyObject` parameters are skipped from the hints: they accept any Python object and render as `Any`, carrying no type information — they are typically the very overloads that just rejected the value. If every candidate takes a `PyObject`, they are shown anyway rather than producing no hint at all.

Before / after for a failed bind:

```
range_consolidator(Int32 range, Func[IBaseData, Decimal] selector = None)
range_consolidator(range: int, selector: Callable[[IBaseData], float] = None)
```

### Does this close any currently open issues?

No.

### Any other comments?

The binder's "No method matches given arguments" message structure is unchanged; only the type names inside the hinted signatures changed. Existing message tests (`TestFloatToIntConversion`, `TestCallbacks`) updated where they asserted C# type names, and a new `TestMethodSignatureFormatter` suite covers the type mapping (primitives, datetime/timedelta, Optional, Callable, List/Dict, Any, CLR-only names, constructor display names).

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change (`TestMethodSignatureFormatter` + updated `TestFloatToIntConversion` / `TestCallbacks` assertions)
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Ensure you have signed the [.NET Foundation CLA](https://cla.dotnetfoundation.org/pythonnet/pythonnet)
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
