### PR TITLE
Name the unexpected keyword argument in the bind-failure TypeError

### DIFF
--- a/src/runtime/MethodBinder.cs
+++ b/src/runtime/MethodBinder.cs
@@ -1016,6 +1016,14 @@ namespace Python.Runtime
                 // If we already have an exception pending, don't create a new one
                 if (!Exceptions.ErrorOccurred())
                 {
+                    // A keyword argument whose name no candidate overload accepts gets the
+                    // Python-native "unexpected keyword argument" error: the generic no-match
+                    // message below does not echo kwargs, leaving the actual mistake invisible.
+                    if (TryRaiseUnexpectedKeywordArgumentError(kw, info, methodinfo))
+                    {
+                        return default;
+                    }
+
                     var value = new StringBuilder("No method matches given arguments");
                     // Use the snake_case name Python callers use, matching the hinted signatures below.
                     if (methodinfo != null && methodinfo.Length > 0)
@@ -1121,6 +1129,134 @@ namespace Python.Runtime
             }
 
             return Converter.ToPython(result, returnType);
+        }
+
+        /// <summary>
+        /// When a bind failure involves a keyword argument whose name no candidate overload
+        /// accepts, raises the Python-style "got an unexpected keyword argument" TypeError
+        /// (with a "Did you mean" hint when a similarly-named parameter exists) and returns
+        /// true. Returns false when every kwarg name is accepted by at least one overload,
+        /// so the generic no-match error is raised instead.
+        /// </summary>
+        private bool TryRaiseUnexpectedKeywordArgumentError(BorrowedReference kw, MethodBase info, MethodInfo[] methodinfo)
+        {
+            var kwCount = kw == null ? 0 : (int)Runtime.PyDict_Size(kw);
+            if (kwCount <= 0)
+            {
+                return false;
+            }
+
+            // The same candidate set Bind considered: parameter names are snake_case for
+            // snake_case-registered methods and original for the original ones, matching
+            // the names the caller can actually use.
+            var methods = info == null
+                ? GetMethods()
+                : new List<MethodInformation>(1) { new MethodInformation(info, true) };
+            var parameterNames = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var method in methods)
+            {
+                foreach (var parameterName in method.ParameterNames)
+                {
+                    parameterNames.Add(parameterName);
+                }
+            }
+
+            // Report the first unknown kwarg in call order, like CPython does.
+            string unexpectedName = null;
+            using (var keyList = Runtime.PyDict_Keys(kw))
+            {
+                for (var i = 0; i < kwCount && unexpectedName == null; i++)
+                {
+                    var name = Runtime.GetManagedString(Runtime.PyList_GetItem(keyList.Borrow(), i));
+                    if (name != null && !parameterNames.Contains(name))
+                    {
+                        unexpectedName = name;
+                    }
+                }
+            }
+
+            if (unexpectedName == null)
+            {
+                return false;
+            }
+
+            string methodName = null;
+            if (methodinfo != null && methodinfo.Length > 0)
+            {
+                methodName = MethodSignatureFormatter.SnakeCaseName(methodinfo[0]);
+            }
+            else if (list.Count > 0)
+            {
+                methodName = MethodSignatureFormatter.SnakeCaseName(list[0].MethodBase);
+            }
+            if (string.IsNullOrEmpty(methodName))
+            {
+                return false;
+            }
+
+            var message = $"{methodName}() got an unexpected keyword argument '{unexpectedName}'";
+            var suggestion = ClosestParameterName(unexpectedName, parameterNames);
+            if (suggestion != null)
+            {
+                message += $". Did you mean '{suggestion}'?";
+            }
+
+            Exceptions.RaiseTypeError(message);
+            return true;
+        }
+
+        /// <summary>
+        /// The candidate parameter name closest to the unexpected kwarg name, or null when
+        /// none is similar enough to suggest. A candidate is considered when it is within
+        /// a small edit distance of the name, or when one contains the other (e.g. 'as_tag'
+        /// suggests 'tag'); containment requires 3+ characters so tiny names don't match.
+        /// </summary>
+        private static string ClosestParameterName(string name, HashSet<string> parameterNames)
+        {
+            const int MinContainmentLength = 3;
+            var threshold = Math.Max(2, name.Length / 3);
+            string best = null;
+            var bestDistance = int.MaxValue;
+            foreach (var candidate in parameterNames)
+            {
+                var distance = KeywordEditDistance(name, candidate);
+                var related = distance <= threshold
+                    || (candidate.Length >= MinContainmentLength && name.Length >= MinContainmentLength
+                        && (candidate.IndexOf(name, StringComparison.OrdinalIgnoreCase) >= 0
+                            || name.IndexOf(candidate, StringComparison.OrdinalIgnoreCase) >= 0));
+                if (related && (distance < bestDistance
+                    || (distance == bestDistance && string.CompareOrdinal(candidate, best) < 0)))
+                {
+                    bestDistance = distance;
+                    best = candidate;
+                }
+            }
+            return best;
+        }
+
+        // Case-insensitive Levenshtein distance, local to keyword suggestions.
+        private static int KeywordEditDistance(string a, string b)
+        {
+            a = a.ToLowerInvariant();
+            b = b.ToLowerInvariant();
+            if (a.Length == 0) return b.Length;
+            if (b.Length == 0) return a.Length;
+
+            var prev = new int[b.Length + 1];
+            var curr = new int[b.Length + 1];
+            for (var j = 0; j <= b.Length; j++) prev[j] = j;
+
+            for (var i = 1; i <= a.Length; i++)
+            {
+                curr[0] = i;
+                for (var j = 1; j <= b.Length; j++)
+                {
+                    var cost = a[i - 1] == b[j - 1] ? 0 : 1;
+                    curr[j] = Math.Min(Math.Min(curr[j - 1] + 1, prev[j] + 1), prev[j - 1] + cost);
+                }
+                (prev, curr) = (curr, prev);
+            }
+            return prev[b.Length];
         }
 
         /// <summary>

--- a/src/runtime/MethodBinder.cs
+++ b/src/runtime/MethodBinder.cs
@@ -1016,12 +1016,6 @@ namespace Python.Runtime
                 // If we already have an exception pending, don't create a new one
                 if (!Exceptions.ErrorOccurred())
                 {
-                    // Unknown kwarg names get the Python-style error; the generic message below does not echo kwargs.
-                    if (TryRaiseUnexpectedKeywordArgumentError(kw, info, methodinfo))
-                    {
-                        return default;
-                    }
-
                     var value = new StringBuilder("No method matches given arguments");
                     // Use the snake_case name Python callers use, matching the hinted signatures below.
                     if (methodinfo != null && methodinfo.Length > 0)
@@ -1036,6 +1030,10 @@ namespace Python.Runtime
                     value.Append(": ");
                     AppendArgumentTypes(to: value, args);
 
+                    // The argument types echo above covers positional args only; name the first
+                    // unknown kwarg (if any) so a misspelled keyword argument is visible.
+                    AppendUnexpectedKeywordArgument(value, kw, info);
+
                     // List the candidate overloads so the caller can see what was
                     // expected (e.g. that an int overload exists when a float was
                     // passed). Applies to every "no match" case, not just numeric ones.
@@ -1045,7 +1043,12 @@ namespace Python.Runtime
                     var overloads = MethodSignatureFormatter.FormatOverloads(candidates);
                     if (overloads.Length > 0)
                     {
-                        value.Append(". ").Append(overloads);
+                        // The kwarg hint may already end the sentence with a question mark.
+                        if (value[value.Length - 1] != '?')
+                        {
+                            value.Append('.');
+                        }
+                        value.Append(' ').Append(overloads);
                     }
 
                     Exceptions.RaiseTypeError(value.ToString());
@@ -1130,15 +1133,16 @@ namespace Python.Runtime
         }
 
         /// <summary>
-        /// Raises "got an unexpected keyword argument" and returns true when a kwarg name is
-        /// accepted by no candidate overload; returns false to let the generic no-match error be raised.
+        /// Appends "Got an unexpected keyword argument" to the no-match message when a kwarg
+        /// name is accepted by no candidate overload, with a "Did you mean" suggestion when a
+        /// similar parameter name exists. Appends nothing when every kwarg name is valid.
         /// </summary>
-        private bool TryRaiseUnexpectedKeywordArgumentError(BorrowedReference kw, MethodBase info, MethodInfo[] methodinfo)
+        private void AppendUnexpectedKeywordArgument(StringBuilder to, BorrowedReference kw, MethodBase info)
         {
             var kwCount = kw == null ? 0 : (int)Runtime.PyDict_Size(kw);
             if (kwCount <= 0)
             {
-                return false;
+                return;
             }
 
             // Same candidate set Bind considered; ParameterNames are already in the caller's convention.
@@ -1170,32 +1174,15 @@ namespace Python.Runtime
 
             if (unexpectedName == null)
             {
-                return false;
+                return;
             }
 
-            string methodName = null;
-            if (methodinfo != null && methodinfo.Length > 0)
-            {
-                methodName = MethodSignatureFormatter.SnakeCaseName(methodinfo[0]);
-            }
-            else if (list.Count > 0)
-            {
-                methodName = MethodSignatureFormatter.SnakeCaseName(list[0].MethodBase);
-            }
-            if (string.IsNullOrEmpty(methodName))
-            {
-                return false;
-            }
-
-            var message = $"{methodName}() got an unexpected keyword argument '{unexpectedName}'";
+            to.Append($". Got an unexpected keyword argument '{unexpectedName}'");
             var suggestion = ClosestParameterName(unexpectedName, parameterNames);
             if (suggestion != null)
             {
-                message += $". Did you mean '{suggestion}'?";
+                to.Append($". Did you mean '{suggestion}'?");
             }
-
-            Exceptions.RaiseTypeError(message);
-            return true;
         }
 
         /// <summary>

--- a/src/runtime/MethodBinder.cs
+++ b/src/runtime/MethodBinder.cs
@@ -1210,7 +1210,7 @@ namespace Python.Runtime
             var bestDistance = int.MaxValue;
             foreach (var candidate in parameterNames)
             {
-                var distance = KeywordEditDistance(name, candidate);
+                var distance = Util.LevenshteinDistance(name, candidate);
                 var related = distance <= threshold
                     || (candidate.Length >= MinContainmentLength && name.Length >= MinContainmentLength
                         && (candidate.IndexOf(name, StringComparison.OrdinalIgnoreCase) >= 0
@@ -1223,31 +1223,6 @@ namespace Python.Runtime
                 }
             }
             return best;
-        }
-
-        // Case-insensitive Levenshtein distance.
-        private static int KeywordEditDistance(string a, string b)
-        {
-            a = a.ToLowerInvariant();
-            b = b.ToLowerInvariant();
-            if (a.Length == 0) return b.Length;
-            if (b.Length == 0) return a.Length;
-
-            var prev = new int[b.Length + 1];
-            var curr = new int[b.Length + 1];
-            for (var j = 0; j <= b.Length; j++) prev[j] = j;
-
-            for (var i = 1; i <= a.Length; i++)
-            {
-                curr[0] = i;
-                for (var j = 1; j <= b.Length; j++)
-                {
-                    var cost = a[i - 1] == b[j - 1] ? 0 : 1;
-                    curr[j] = Math.Min(Math.Min(curr[j - 1] + 1, prev[j] + 1), prev[j - 1] + cost);
-                }
-                (prev, curr) = (curr, prev);
-            }
-            return prev[b.Length];
         }
 
         /// <summary>

--- a/src/runtime/MethodBinder.cs
+++ b/src/runtime/MethodBinder.cs
@@ -1017,38 +1017,48 @@ namespace Python.Runtime
                 if (!Exceptions.ErrorOccurred())
                 {
                     var value = new StringBuilder("No method matches given arguments");
-                    // Use the snake_case name Python callers use, matching the hinted signatures below.
-                    if (methodinfo != null && methodinfo.Length > 0)
+                    try
                     {
-                        value.Append($" for {MethodSignatureFormatter.SnakeCaseName(methodinfo[0])}");
-                    }
-                    else if (list.Count > 0)
-                    {
-                        value.Append($" for {MethodSignatureFormatter.SnakeCaseName(list[0].MethodBase)}");
-                    }
-
-                    value.Append(": ");
-                    AppendArgumentTypes(to: value, args);
-
-                    // The argument types echo above covers positional args only; name the first
-                    // unknown kwarg (if any) so a misspelled keyword argument is visible.
-                    AppendUnexpectedKeywordArgument(value, kw, info);
-
-                    // List the candidate overloads so the caller can see what was
-                    // expected (e.g. that an int overload exists when a float was
-                    // passed). Applies to every "no match" case, not just numeric ones.
-                    var candidates = methodinfo != null && methodinfo.Length > 0
-                        ? methodinfo.Cast<MethodBase>()
-                        : list?.Select(m => m.MethodBase);
-                    var overloads = MethodSignatureFormatter.FormatOverloads(candidates);
-                    if (overloads.Length > 0)
-                    {
-                        // The kwarg hint may already end the sentence with a question mark.
-                        if (value[value.Length - 1] != '?')
+                        // Use the snake_case name Python callers use, matching the hinted signatures below.
+                        if (methodinfo != null && methodinfo.Length > 0)
                         {
-                            value.Append('.');
+                            value.Append($" for {MethodSignatureFormatter.SnakeCaseName(methodinfo[0])}");
                         }
-                        value.Append(' ').Append(overloads);
+                        else if (list.Count > 0)
+                        {
+                            value.Append($" for {MethodSignatureFormatter.SnakeCaseName(list[0].MethodBase)}");
+                        }
+
+                        value.Append(": ");
+                        AppendArgumentTypes(to: value, args);
+
+                        // The argument types echo above covers positional args only; name the first
+                        // unknown kwarg (if any) so a misspelled keyword argument is visible.
+                        AppendUnexpectedKeywordArgument(value, kw, info);
+
+                        // List the candidate overloads so the caller can see what was
+                        // expected (e.g. that an int overload exists when a float was
+                        // passed). Applies to every "no match" case, not just numeric ones.
+                        var candidates = methodinfo != null && methodinfo.Length > 0
+                            ? methodinfo.Cast<MethodBase>()
+                            : list?.Select(m => m.MethodBase);
+                        var overloads = MethodSignatureFormatter.FormatOverloads(candidates);
+                        if (overloads.Length > 0)
+                        {
+                            // The kwarg hint may already end the sentence with a question mark.
+                            if (value[value.Length - 1] != '?')
+                            {
+                                value.Append('.');
+                            }
+                            value.Append(' ').Append(overloads);
+                        }
+                    }
+                    catch
+                    {
+                        // The details above are best-effort diagnostics over arbitrary caller
+                        // input; an exception here would escape the tp_call slot into CPython
+                        // and mask the bind failure. Raise with whatever was appended so far.
+                        Exceptions.Clear();
                     }
 
                     Exceptions.RaiseTypeError(value.ToString());

--- a/src/runtime/MethodBinder.cs
+++ b/src/runtime/MethodBinder.cs
@@ -1016,9 +1016,7 @@ namespace Python.Runtime
                 // If we already have an exception pending, don't create a new one
                 if (!Exceptions.ErrorOccurred())
                 {
-                    // A keyword argument whose name no candidate overload accepts gets the
-                    // Python-native "unexpected keyword argument" error: the generic no-match
-                    // message below does not echo kwargs, leaving the actual mistake invisible.
+                    // Unknown kwarg names get the Python-style error; the generic message below does not echo kwargs.
                     if (TryRaiseUnexpectedKeywordArgumentError(kw, info, methodinfo))
                     {
                         return default;
@@ -1132,11 +1130,8 @@ namespace Python.Runtime
         }
 
         /// <summary>
-        /// When a bind failure involves a keyword argument whose name no candidate overload
-        /// accepts, raises the Python-style "got an unexpected keyword argument" TypeError
-        /// (with a "Did you mean" hint when a similarly-named parameter exists) and returns
-        /// true. Returns false when every kwarg name is accepted by at least one overload,
-        /// so the generic no-match error is raised instead.
+        /// Raises "got an unexpected keyword argument" and returns true when a kwarg name is
+        /// accepted by no candidate overload; returns false to let the generic no-match error be raised.
         /// </summary>
         private bool TryRaiseUnexpectedKeywordArgumentError(BorrowedReference kw, MethodBase info, MethodInfo[] methodinfo)
         {
@@ -1146,9 +1141,7 @@ namespace Python.Runtime
                 return false;
             }
 
-            // The same candidate set Bind considered: parameter names are snake_case for
-            // snake_case-registered methods and original for the original ones, matching
-            // the names the caller can actually use.
+            // Same candidate set Bind considered; ParameterNames are already in the caller's convention.
             var methods = info == null
                 ? GetMethods()
                 : new List<MethodInformation>(1) { new MethodInformation(info, true) };
@@ -1206,10 +1199,8 @@ namespace Python.Runtime
         }
 
         /// <summary>
-        /// The candidate parameter name closest to the unexpected kwarg name, or null when
-        /// none is similar enough to suggest. A candidate is considered when it is within
-        /// a small edit distance of the name, or when one contains the other (e.g. 'as_tag'
-        /// suggests 'tag'); containment requires 3+ characters so tiny names don't match.
+        /// Closest parameter name to suggest, or null: small edit distance, or containment
+        /// between names of 3+ characters (e.g. 'as_tag' suggests 'tag').
         /// </summary>
         private static string ClosestParameterName(string name, HashSet<string> parameterNames)
         {
@@ -1234,7 +1225,7 @@ namespace Python.Runtime
             return best;
         }
 
-        // Case-insensitive Levenshtein distance, local to keyword suggestions.
+        // Case-insensitive Levenshtein distance.
         private static int KeywordEditDistance(string a, string b)
         {
             a = a.ToLowerInvariant();

--- a/src/runtime/Types/ClassBase.cs
+++ b/src/runtime/Types/ClassBase.cs
@@ -845,7 +845,7 @@ namespace Python.Runtime
             var scored = new List<(string Name, int Distance, SuggestionKind Kind)>();
             foreach (var candidate in GetCandidateMemberNames(type))
             {
-                var distance = LevenshteinDistance(name, candidate.Key);
+                var distance = Util.LevenshteinDistance(name, candidate.Key);
                 var related = distance <= threshold
                     || candidate.Key.IndexOf(name, StringComparison.OrdinalIgnoreCase) >= 0
                     || name.IndexOf(candidate.Key, StringComparison.OrdinalIgnoreCase) >= 0;
@@ -895,30 +895,5 @@ namespace Python.Runtime
             };
         }
 
-        private static int LevenshteinDistance(string a, string b)
-        {
-            a = a.ToLowerInvariant();
-            b = b.ToLowerInvariant();
-            var n = a.Length;
-            var m = b.Length;
-            if (n == 0) return m;
-            if (m == 0) return n;
-
-            var prev = new int[m + 1];
-            var curr = new int[m + 1];
-            for (var j = 0; j <= m; j++) prev[j] = j;
-
-            for (var i = 1; i <= n; i++)
-            {
-                curr[0] = i;
-                for (var j = 1; j <= m; j++)
-                {
-                    var cost = a[i - 1] == b[j - 1] ? 0 : 1;
-                    curr[j] = Math.Min(Math.Min(curr[j - 1] + 1, prev[j] + 1), prev[j - 1] + cost);
-                }
-                (prev, curr) = (curr, prev);
-            }
-            return prev[m];
-        }
     }
 }

--- a/src/runtime/Util/Util.cs
+++ b/src/runtime/Util/Util.cs
@@ -336,5 +336,32 @@ namespace Python.Runtime
                     return false;
             }
         }
+
+        // Case-insensitive Levenshtein distance.
+        internal static int LevenshteinDistance(string a, string b)
+        {
+            a = a.ToLowerInvariant();
+            b = b.ToLowerInvariant();
+            var n = a.Length;
+            var m = b.Length;
+            if (n == 0) return m;
+            if (m == 0) return n;
+
+            var prev = new int[m + 1];
+            var curr = new int[m + 1];
+            for (var j = 0; j <= m; j++) prev[j] = j;
+
+            for (var i = 1; i <= n; i++)
+            {
+                curr[0] = i;
+                for (var j = 1; j <= m; j++)
+                {
+                    var cost = a[i - 1] == b[j - 1] ? 0 : 1;
+                    curr[j] = Math.Min(Math.Min(curr[j - 1] + 1, prev[j] + 1), prev[j - 1] + cost);
+                }
+                (prev, curr) = (curr, prev);
+            }
+            return prev[m];
+        }
     }
 }

--- a/src/testing/methodtest.cs
+++ b/src/testing/methodtest.cs
@@ -709,6 +709,11 @@ namespace Python.Test
             return $"{a}{b}{c}{d}XXX";
         }
 
+        public static string OrderLikeMethod(string symbol, decimal quantity, bool asynchronous = false, string tag = "", object orderProperties = null)
+        {
+            return string.Format("{0}:{1}:{2}:{3}", symbol, quantity, asynchronous, tag);
+        }
+
         public static string ParamsArrayOverloaded(int i = 1)
         {
             return "without params-array";

--- a/tests/test_method.py
+++ b/tests/test_method.py
@@ -1105,16 +1105,13 @@ def test_default_params():
         MethodTest.DefaultParams(1,2,3,4,5)
 
 def test_unexpected_keyword_argument_with_suggestion():
-    # A kwarg no overload accepts raises the Python-style error naming the kwarg,
-    # with a did-you-mean hint when a similarly-named parameter exists.
     with pytest.raises(TypeError) as excinfo:
         MethodTest.order_like_method("SPY", 10, as_tag="EmergencyFlatten")
     message = str(excinfo.value)
     assert "order_like_method() got an unexpected keyword argument 'as_tag'" in message
     assert "Did you mean 'tag'?" in message
 
-    # Same behavior when calling through the original PascalCase name; parameter
-    # names are the original ones there.
+    # PascalCase call path: parameter names are the original ones.
     with pytest.raises(TypeError) as excinfo:
         MethodTest.OrderLikeMethod("SPY", 10, asTag="EmergencyFlatten")
     message = str(excinfo.value)
@@ -1123,7 +1120,6 @@ def test_unexpected_keyword_argument_with_suggestion():
 
 
 def test_unexpected_keyword_argument_without_suggestion():
-    # No parameter is remotely similar: the kwarg is still named, but no hint is added.
     with pytest.raises(TypeError) as excinfo:
         MethodTest.order_like_method("SPY", 10, completely_unrelated_name=1)
     message = str(excinfo.value)
@@ -1144,9 +1140,7 @@ def test_valid_keyword_arguments_still_bind():
 
 
 def test_valid_keyword_argument_names_keep_no_match_message():
-    # All kwarg names are real parameters, but the call still cannot bind ('d' is
-    # supplied both positionally and by name): the classic no-method-matches
-    # message must be preserved for this case.
+    # 'd' is supplied both positionally and by name: valid names, unbindable call.
     with pytest.raises(TypeError) as excinfo:
         MethodTest.DefaultParams(1, 2, 3, 4, d=5)
     assert "No method matches given arguments for default_params" in str(excinfo.value)

--- a/tests/test_method.py
+++ b/tests/test_method.py
@@ -1104,6 +1104,53 @@ def test_default_params():
     with pytest.raises(TypeError):
         MethodTest.DefaultParams(1,2,3,4,5)
 
+def test_unexpected_keyword_argument_with_suggestion():
+    # A kwarg no overload accepts raises the Python-style error naming the kwarg,
+    # with a did-you-mean hint when a similarly-named parameter exists.
+    with pytest.raises(TypeError) as excinfo:
+        MethodTest.order_like_method("SPY", 10, as_tag="EmergencyFlatten")
+    message = str(excinfo.value)
+    assert "order_like_method() got an unexpected keyword argument 'as_tag'" in message
+    assert "Did you mean 'tag'?" in message
+
+    # Same behavior when calling through the original PascalCase name; parameter
+    # names are the original ones there.
+    with pytest.raises(TypeError) as excinfo:
+        MethodTest.OrderLikeMethod("SPY", 10, asTag="EmergencyFlatten")
+    message = str(excinfo.value)
+    assert "order_like_method() got an unexpected keyword argument 'asTag'" in message
+    assert "Did you mean 'tag'?" in message
+
+
+def test_unexpected_keyword_argument_without_suggestion():
+    # No parameter is remotely similar: the kwarg is still named, but no hint is added.
+    with pytest.raises(TypeError) as excinfo:
+        MethodTest.order_like_method("SPY", 10, completely_unrelated_name=1)
+    message = str(excinfo.value)
+    assert "order_like_method() got an unexpected keyword argument " \
+           "'completely_unrelated_name'" in message
+    assert "Did you mean" not in message
+
+
+def test_unexpected_keyword_argument_reports_first_in_call_order():
+    with pytest.raises(TypeError) as excinfo:
+        MethodTest.order_like_method("SPY", 10, first_bogus=1, second_bogus=2)
+    assert "got an unexpected keyword argument 'first_bogus'" in str(excinfo.value)
+
+
+def test_valid_keyword_arguments_still_bind():
+    res = MethodTest.order_like_method("SPY", 10, asynchronous=True, tag="mytag")
+    assert res == "SPY:10:True:mytag"
+
+
+def test_valid_keyword_argument_names_keep_no_match_message():
+    # All kwarg names are real parameters, but the call still cannot bind ('d' is
+    # supplied both positionally and by name): the classic no-method-matches
+    # message must be preserved for this case.
+    with pytest.raises(TypeError) as excinfo:
+        MethodTest.DefaultParams(1, 2, 3, 4, d=5)
+    assert "No method matches given arguments for default_params" in str(excinfo.value)
+
 def test_optional_params():
     res = MethodTest.OptionalParams(1, 2, 3, 4)
     assert res == "1234"

--- a/tests/test_method.py
+++ b/tests/test_method.py
@@ -1108,14 +1108,16 @@ def test_unexpected_keyword_argument_with_suggestion():
     with pytest.raises(TypeError) as excinfo:
         MethodTest.order_like_method("SPY", 10, as_tag="EmergencyFlatten")
     message = str(excinfo.value)
-    assert "order_like_method() got an unexpected keyword argument 'as_tag'" in message
+    assert "No method matches given arguments for order_like_method" in message
+    assert "Got an unexpected keyword argument 'as_tag'" in message
     assert "Did you mean 'tag'?" in message
 
     # PascalCase call path: parameter names are the original ones.
     with pytest.raises(TypeError) as excinfo:
         MethodTest.OrderLikeMethod("SPY", 10, asTag="EmergencyFlatten")
     message = str(excinfo.value)
-    assert "order_like_method() got an unexpected keyword argument 'asTag'" in message
+    assert "No method matches given arguments for order_like_method" in message
+    assert "Got an unexpected keyword argument 'asTag'" in message
     assert "Did you mean 'tag'?" in message
 
 
@@ -1123,7 +1125,8 @@ def test_unexpected_keyword_argument_without_suggestion():
     with pytest.raises(TypeError) as excinfo:
         MethodTest.order_like_method("SPY", 10, completely_unrelated_name=1)
     message = str(excinfo.value)
-    assert "order_like_method() got an unexpected keyword argument " \
+    assert "No method matches given arguments for order_like_method" in message
+    assert "Got an unexpected keyword argument " \
            "'completely_unrelated_name'" in message
     assert "Did you mean" not in message
 
@@ -1131,7 +1134,7 @@ def test_unexpected_keyword_argument_without_suggestion():
 def test_unexpected_keyword_argument_reports_first_in_call_order():
     with pytest.raises(TypeError) as excinfo:
         MethodTest.order_like_method("SPY", 10, first_bogus=1, second_bogus=2)
-    assert "got an unexpected keyword argument 'first_bogus'" in str(excinfo.value)
+    assert "Got an unexpected keyword argument 'first_bogus'" in str(excinfo.value)
 
 
 def test_valid_keyword_arguments_still_bind():
@@ -1143,7 +1146,9 @@ def test_valid_keyword_argument_names_keep_no_match_message():
     # 'd' is supplied both positionally and by name: valid names, unbindable call.
     with pytest.raises(TypeError) as excinfo:
         MethodTest.DefaultParams(1, 2, 3, 4, d=5)
-    assert "No method matches given arguments for default_params" in str(excinfo.value)
+    message = str(excinfo.value)
+    assert "No method matches given arguments for default_params" in message
+    assert "unexpected keyword argument" not in message
 
 def test_optional_params():
     res = MethodTest.OptionalParams(1, 2, 3, 4)


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

When a call fails to bind because of a misspelled keyword argument, the error did not mention the kwarg at all — only positional argument types are echoed — so the actual mistake was invisible:

```
market_order(symbol, -10, as_tag="EmergencyFlatten")
TypeError: No method matches given arguments for market_order: (<class 'QuantConnect.Symbol'>, <class 'int'>). The following overloads are available: ...
```

Cause: `MethodBinder.Invoke`'s bind-failure path builds its message from the positional args tuple only and has no unexpected-keyword-argument path.

The fix:
- `MethodBinder.AppendUnexpectedKeywordArgument` runs while the bind-failure message is built: when a supplied kwarg name is accepted by no candidate overload (same candidate set `Bind` used, so snake_case and original parameter names are matched exactly like binding does), it extends the existing message — right after the positional argument types, before the overload list — naming the first unknown kwarg in call order like CPython:

  ```
  TypeError: No method matches given arguments for market_order: (<class 'QuantConnect.Symbol'>, <class 'int'>). Got an unexpected keyword argument 'as_tag'. Did you mean 'tag'? The following overloads are available: ...
  ```

- The `Did you mean` hint suggests the closest parameter name across all overloads (small local Levenshtein plus containment for 3+ character names); it is omitted when nothing is similar.
- When every kwarg name is valid for some overload but binding still fails (e.g. a type mismatch, or an argument supplied both positionally and by name), the message is unchanged.
- The whole message-construction block (including the pre-existing name/argument-types/overloads parts) is now wrapped in a try/catch: it runs over arbitrary caller input inside the `tp_call` slot, where an escaping exception would propagate into CPython and mask the bind failure; on error the `TypeError` is raised with whatever was appended so far.

A complete message as produced against the new test fixture:

```
TypeError: No method matches given arguments for order_like_method: (<class 'str'>, <class 'int'>). Got an unexpected keyword argument 'as_tag'. Did you mean 'tag'? The expected signature is:
  order_like_method(symbol: str, quantity: float, asynchronous: bool = False, tag: str = "", order_properties: Any = None)
```

Note: the message keeps the `No method matches given arguments for {name}:` prefix, so Lean's `NoMethodMatchPythonExceptionInterpreter` keeps matching and rewriting it exactly as before; the kwarg detail rides along inside it.

Note on #147: `ClassBase`'s private `LevenshteinDistance` moved verbatim to `Util.LevenshteinDistance`, used by both `ClassBase` and `MethodBinder`. #147 deletes the `ClassBase` call site in favor of Jaro-Winkler; the shared helper remains for `MethodBinder`, so the merge interplay is a trivial deletion on their side.

### Does this close any currently open issues?

No. Part of the error-surface improvements from QuantConnect/Agents#305 (improvement 1: fleet evidence A-70ad2e3b).

### Any other comments?

Tests:
- `test_unexpected_keyword_argument_with_suggestion`: unknown kwarg via both the snake_case and original PascalCase method names; asserts the no-match prefix is kept, the kwarg is named, and `Did you mean 'tag'?` is suggested.
- `test_unexpected_keyword_argument_without_suggestion`: unrelated kwarg name; asserts no `Did you mean` hint.
- `test_unexpected_keyword_argument_reports_first_in_call_order`: two unknown kwargs; asserts the first is reported.
- `test_valid_keyword_arguments_still_bind`: valid kwargs on the new fixture method bind and execute.
- `test_valid_keyword_argument_names_keep_no_match_message`: valid kwarg names with an unbindable call keep the classic no-method-matches message with no kwarg detail appended.
- Full python suite (`py -3.11 -m pytest --runtime netcore tests`): 461 passed, 23 skipped, 1 failed — the failure (`test_explicit_assembly_load`) is environmental and fails identically on unmodified master.
- Full embed suite (`dotnet test src/embed_tests -c Release`): 971 passed, 0 failed, 8 skipped.

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Ensure you have signed the [.NET Foundation CLA](https://cla.dotnetfoundation.org/pythonnet/pythonnet)
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
