### PR TITLE
Reject non-integral float-like values (numpy floats) for integer parameters

### DIFF
--- a/src/embed_tests/TestFloatToIntConversion.cs
+++ b/src/embed_tests/TestFloatToIntConversion.cs
@@ -41,6 +41,43 @@ def overloaded_named(value):
 
 def single_params(value):
     return IntTaker(0).ComputeScaled(value)
+
+class FloatSubclass(float):
+    # numpy.float64-like: a float subclass
+    pass
+
+class FloatLike:
+    # numpy.float32-like: float and (truncating) int conversions, no __index__
+    def __init__(self, v):
+        self._v = v
+    def __float__(self):
+        return float(self._v)
+    def __int__(self):
+        return int(self._v)
+
+class IndexLike:
+    # numpy.int64-like: a true integer type advertising __index__
+    def __init__(self, v):
+        self._v = v
+    def __index__(self):
+        return int(self._v)
+    def __float__(self):
+        return float(self._v)
+
+def single_ctor_float_subclass(value):
+    return IntTaker(FloatSubclass(value)).Value
+
+def overloaded_ctor_float_subclass(value):
+    return OverloadedIntTaker(FloatSubclass(value)).Value
+
+def single_ctor_float_like(value):
+    return IntTaker(FloatLike(value)).Value
+
+def overloaded_ctor_float_like(value):
+    return OverloadedIntTaker(FloatLike(value)).Value
+
+def single_ctor_index_like(value):
+    return IntTaker(IndexLike(value)).Value
 ";
 
         [OneTimeSetUp]
@@ -85,6 +122,50 @@ def single_params(value):
         {
             var ex = Assert.Throws<PythonException>(() => Call(func, 5.5));
             Assert.AreEqual("TypeError", ex.Type.Name);
+        }
+
+        // A float subclass (e.g. numpy.float64) follows the same rule as a plain
+        // float: integral values convert, fractional ones are rejected instead of
+        // being silently truncated through __int__.
+        [TestCase("single_ctor_float_subclass")]
+        [TestCase("overloaded_ctor_float_subclass")]
+        public void IntegralFloatSubclass_IsAccepted(string func)
+        {
+            Assert.AreEqual(5, Call(func, 5.0));
+        }
+
+        [TestCase("single_ctor_float_subclass")]
+        [TestCase("overloaded_ctor_float_subclass")]
+        public void NonIntegralFloatSubclass_IsRejected(string func)
+        {
+            var ex = Assert.Throws<PythonException>(() => Call(func, 5.5));
+            Assert.AreEqual("TypeError", ex.Type.Name);
+        }
+
+        // A number that defines __float__ but no __index__ (e.g. numpy.float32) is
+        // float-like: integral values convert, fractional ones are rejected instead
+        // of being silently truncated through __int__.
+        [TestCase("single_ctor_float_like")]
+        [TestCase("overloaded_ctor_float_like")]
+        public void IntegralFloatLike_IsAccepted(string func)
+        {
+            Assert.AreEqual(5, Call(func, 5.0));
+        }
+
+        [TestCase("single_ctor_float_like")]
+        [TestCase("overloaded_ctor_float_like")]
+        public void NonIntegralFloatLike_IsRejected(string func)
+        {
+            var ex = Assert.Throws<PythonException>(() => Call(func, 5.5));
+            Assert.AreEqual("TypeError", ex.Type.Name);
+        }
+
+        // A true integer type advertising __index__ (e.g. numpy.int64) is not
+        // float-like and keeps converting even though it also defines __float__.
+        [Test]
+        public void IndexLike_IsAccepted()
+        {
+            Assert.AreEqual(5, Call("single_ctor_index_like", 5.0));
         }
 
         // When no overload matches, the error should hint the expected signature(s).

--- a/src/embed_tests/TestFloatToIntConversion.cs
+++ b/src/embed_tests/TestFloatToIntConversion.cs
@@ -124,9 +124,7 @@ def single_ctor_index_like(value):
             Assert.AreEqual("TypeError", ex.Type.Name);
         }
 
-        // A float subclass (e.g. numpy.float64) follows the same rule as a plain
-        // float: integral values convert, fractional ones are rejected instead of
-        // being silently truncated through __int__.
+        // Float subclasses (e.g. numpy.float64) follow the plain-float rule.
         [TestCase("single_ctor_float_subclass")]
         [TestCase("overloaded_ctor_float_subclass")]
         public void IntegralFloatSubclass_IsAccepted(string func)
@@ -142,9 +140,7 @@ def single_ctor_index_like(value):
             Assert.AreEqual("TypeError", ex.Type.Name);
         }
 
-        // A number that defines __float__ but no __index__ (e.g. numpy.float32) is
-        // float-like: integral values convert, fractional ones are rejected instead
-        // of being silently truncated through __int__.
+        // __float__-only numbers (e.g. numpy.float32) follow the plain-float rule.
         [TestCase("single_ctor_float_like")]
         [TestCase("overloaded_ctor_float_like")]
         public void IntegralFloatLike_IsAccepted(string func)
@@ -160,8 +156,7 @@ def single_ctor_index_like(value):
             Assert.AreEqual("TypeError", ex.Type.Name);
         }
 
-        // A true integer type advertising __index__ (e.g. numpy.int64) is not
-        // float-like and keeps converting even though it also defines __float__.
+        // __index__ types (e.g. numpy.int64) are integers, not float-like.
         [Test]
         public void IndexLike_IsAccepted()
         {

--- a/src/runtime/Converter.cs
+++ b/src/runtime/Converter.cs
@@ -908,6 +908,31 @@ class GMT(tzinfo):
         }
 
         /// <summary>
+        /// Determines whether a Python value is a floating-point number: a Python
+        /// float (including subclasses such as numpy.float64) or a number that
+        /// defines a float conversion but no lossless integer conversion
+        /// (__float__ without __index__, e.g. numpy.float32). Integer values,
+        /// including bools and types with __index__ such as numpy.int64, are not
+        /// float-like.
+        /// </summary>
+        private static bool IsFloatLike(BorrowedReference value)
+        {
+            // The common case for integer parameters is an actual int; exit fast.
+            if (Runtime.PyInt_Check(value) || Runtime.PyBool_Check(value))
+            {
+                return false;
+            }
+
+            if (Runtime.PyObject_TypeCheck(value, Runtime.PyFloatType))
+            {
+                return true;
+            }
+
+            return Runtime.PyObject_HasAttrString(value, "__float__") != 0
+                && Runtime.PyObject_HasAttrString(value, "__index__") == 0;
+        }
+
+        /// <summary>
         /// Convert a Python value to an instance of a primitive managed type.
         /// </summary>
         internal static bool ToPrimitive(BorrowedReference value, Type obType, out object result, bool setError, out bool usedImplicit)
@@ -918,14 +943,23 @@ class GMT(tzinfo):
 
             TypeCode tc = Type.GetTypeCode(obType);
 
-            // A Python float with a fractional part must not be silently truncated
-            // into an integer parameter. Integral-valued floats (e.g. 5.0) are still
-            // accepted. This keeps single- and multi-overload binding consistent:
-            // MethodBinder only treats integral floats as candidates for integer
-            // parameters, and this guard enforces the same rule at conversion time.
-            if (tc.IsInteger() && Runtime.PyFloat_Check(value))
+            // A float-like value with a fractional part must not be silently truncated
+            // into an integer parameter. Integral-valued ones (e.g. 5.0) are still
+            // accepted. Besides Python floats this covers float subclasses such as
+            // numpy.float64 and __float__-only numbers such as numpy.float32, which
+            // would otherwise be truncated below through PyNumber_Long/__int__.
+            // This keeps single- and multi-overload binding consistent: MethodBinder
+            // only treats integral floats as candidates for integer parameters, and
+            // this guard enforces the same rule at conversion time.
+            if (tc.IsInteger() && IsFloatLike(value))
             {
                 double dbl = Runtime.PyFloat_AsDouble(value);
+                if (dbl == -1.0 && Exceptions.ErrorOccurred())
+                {
+                    // __float__ itself failed; don't let the probe error leak
+                    Exceptions.Clear();
+                    goto type_error;
+                }
                 if (double.IsNaN(dbl) || double.IsInfinity(dbl) || Math.Truncate(dbl) != dbl)
                 {
                     goto type_error;

--- a/src/runtime/Converter.cs
+++ b/src/runtime/Converter.cs
@@ -908,16 +908,13 @@ class GMT(tzinfo):
         }
 
         /// <summary>
-        /// Determines whether a Python value is a floating-point number: a Python
-        /// float (including subclasses such as numpy.float64) or a number that
-        /// defines a float conversion but no lossless integer conversion
-        /// (__float__ without __index__, e.g. numpy.float32). Integer values,
-        /// including bools and types with __index__ such as numpy.int64, are not
-        /// float-like.
+        /// True for Python floats (including subclasses like numpy.float64) and for
+        /// numbers with __float__ but no __index__ (like numpy.float32); __index__
+        /// marks a type as losslessly int-convertible, so those are not float-like.
         /// </summary>
         private static bool IsFloatLike(BorrowedReference value)
         {
-            // The common case for integer parameters is an actual int; exit fast.
+            // fast path for the common case: actual ints
             if (Runtime.PyInt_Check(value) || Runtime.PyBool_Check(value))
             {
                 return false;
@@ -943,20 +940,14 @@ class GMT(tzinfo):
 
             TypeCode tc = Type.GetTypeCode(obType);
 
-            // A float-like value with a fractional part must not be silently truncated
-            // into an integer parameter. Integral-valued ones (e.g. 5.0) are still
-            // accepted. Besides Python floats this covers float subclasses such as
-            // numpy.float64 and __float__-only numbers such as numpy.float32, which
-            // would otherwise be truncated below through PyNumber_Long/__int__.
-            // This keeps single- and multi-overload binding consistent: MethodBinder
-            // only treats integral floats as candidates for integer parameters, and
-            // this guard enforces the same rule at conversion time.
+            // Reject non-integral float-like values (incl. numpy floats) for integer
+            // targets; the PyNumber_Long path below would silently truncate them.
             if (tc.IsInteger() && IsFloatLike(value))
             {
                 double dbl = Runtime.PyFloat_AsDouble(value);
                 if (dbl == -1.0 && Exceptions.ErrorOccurred())
                 {
-                    // __float__ itself failed; don't let the probe error leak
+                    // don't let a failed __float__ probe leak
                     Exceptions.Clear();
                     goto type_error;
                 }

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -267,6 +267,59 @@ def test_int64_conversion():
         _ = System.Int64(-9223372036854775809)
 
 
+def test_numpy_float_to_int_conversion():
+    """A numpy float with a fractional value is rejected for integer targets
+    instead of being silently truncated; integral-valued numpy floats convert.
+    Numpy integer scalars are unaffected."""
+    np = pytest.importorskip("numpy")
+
+    ob = ConversionTest()
+
+    # integral-valued numpy floats convert
+    ob.Int32Field = np.float64(20.0)
+    assert ob.Int32Field == 20
+
+    ob.Int32Field = np.float32(21.0)
+    assert ob.Int32Field == 21
+
+    ob.Int64Field = np.float64(22.0)
+    assert ob.Int64Field == 22
+
+    # non-integral numpy floats are rejected, not truncated
+    with pytest.raises(TypeError):
+        ConversionTest().Int32Field = np.float64(20.5)
+
+    with pytest.raises(TypeError):
+        ConversionTest().Int32Field = np.float32(20.5)
+
+    with pytest.raises(TypeError):
+        ConversionTest().Int64Field = np.float64(20.5)
+
+    # numpy integer scalars keep converting
+    ob.Int32Field = np.int32(7)
+    assert ob.Int32Field == 7
+
+    ob.Int32Field = np.int64(8)
+    assert ob.Int32Field == 8
+
+    ob.Int64Field = np.int64(9)
+    assert ob.Int64Field == 9
+
+    # plain float behavior is unchanged
+    ob.Int32Field = 23.0
+    assert ob.Int32Field == 23
+
+    with pytest.raises(TypeError):
+        ConversionTest().Int32Field = 23.5
+
+    # method binding applies the same rule
+    from Python.Test import MethodTest
+    assert MethodTest.TestOverloadedNoObject(np.float64(5.0)) == "Got int"
+
+    with pytest.raises(TypeError):
+        MethodTest.TestOverloadedNoObject(np.float64(5.5))
+
+
 def test_uint16_conversion():
     """Test uint16 conversion."""
     assert System.UInt16.MaxValue == 65535

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -268,9 +268,7 @@ def test_int64_conversion():
 
 
 def test_numpy_float_to_int_conversion():
-    """A numpy float with a fractional value is rejected for integer targets
-    instead of being silently truncated; integral-valued numpy floats convert.
-    Numpy integer scalars are unaffected."""
+    """Non-integral numpy floats are rejected for integer targets, not truncated."""
     np = pytest.importorskip("numpy")
 
     ob = ConversionTest()


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Passing a non-integral numpy float where a .NET integer parameter is expected silently truncates instead of raising: `SimpleMovingAverage(np.float64(20.5))` builds a period-**20** indicator, while plain `float(20.5)` is correctly rejected with a `TypeError`.

fb5cce6 (#128) added the non-integral rejection for Python floats, but the guard in `Converter.ToPrimitive` uses `Runtime.PyFloat_Check`, an exact type-pointer check. Two kinds of values bypass it and fall through to `PyNumber_Long`/`__int__`, which truncates:

- `float` subclasses — `numpy.float64` is a subclass of Python `float`
- numbers that only define `__float__` — `numpy.float32`/`float16` are not `float` subclasses

This PR extends the guard to any float-like value:

- a Python `float` including subclasses (`PyObject_TypeCheck` against `PyFloatType`), or
- a number defining `__float__` but **not** `__index__` (Python's marker for losslessly-int-convertible types)

Integral-valued floats (`np.float64(20.0)`) keep converting, numpy integer scalars (`np.int64`, `np.int32`, which advertise `__index__`) are unaffected, and plain ints take a fast early exit. If a probed `__float__` call fails, the pending Python error is cleared before rejecting, so no stale error leaks.

Behavior note: non-numpy numeric types with `__float__`/`__int__` but no `__index__` (e.g. `decimal.Decimal`, `fractions.Fraction`) previously also truncated silently into integer parameters (`Decimal("20.5")` → `20`); with this change their non-integral values are rejected the same way, while integral values keep converting exactly as before.

### Does this close any currently open issues?

No open issue; found while reproducing the fleet error-surface study (Agents#305, improvement 1).

### Any other comments?

Tests:

- `TestFloatToIntConversion` embed tests: new float-subclass, `__float__`-only and `__index__` fixture cases over single and overloaded targets (22 pass).
- `tests/test_conversion.py::test_numpy_float_to_int_conversion`: numpy-backed coverage (`np.float64`/`np.float32` integral and non-integral, `np.int32`/`np.int64`, plain-float regression, method binding), skipped automatically when numpy is absent.
- Full embed suite: 982 passed, 0 failed. Full python suite: 457 passed; the single failure (`test_module.py::test_explicit_assembly_load`) is a local-environment artifact and fails identically on clean `master`.

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Ensure you have signed the [.NET Foundation CLA](https://cla.dotnetfoundation.org/pythonnet/pythonnet)
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
