### PR TITLE
Improve missing-attribute suggestions: Jaro-Winkler similarity, gated containment

### DIFF
--- a/src/runtime/Types/ClassBase.cs
+++ b/src/runtime/Types/ClassBase.cs
@@ -838,17 +838,13 @@ namespace Python.Runtime
         // string when no member is similar enough to suggest. The result is cached in
         // _suggestionCache, so this runs at most once per (type, missing-name).
         //
-        // Similarity is Jaro-Winkler rather than a Levenshtein threshold: the prefix-favoring
-        // measure keeps suffix-extended real targets that an edit-distance cutoff rejects
-        // (BrokerageName.InteractiveBrokers -> INTERACTIVE_BROKERS_BROKERAGE is 11 edits away
-        // but 0.92 similar), while naturally rejecting the short-name noise edit distance
-        // admits ('cash' is within 2 edits of 'ASI'). Substring containment is kept as a
-        // fallback signal for fragment lookups Jaro-Winkler cannot see (its match window
-        // rules out 'cash' vs 'set_cash'), but only for fragments long enough to be
-        // meaningful, so 1-2 letter members no longer qualify for every long missed name.
+        // Jaro-Winkler (prefix-favoring) keeps suffix-extended targets that an edit-distance
+        // cutoff rejects (InteractiveBrokers -> INTERACTIVE_BROKERS_BROKERAGE); gated
+        // containment covers fragment lookups outside its match window ('cash' -> 'set_cash').
         private static string ComputeSimilarMemberNames(Type type, string name)
         {
             const int MaxSuggestions = 5;
+            // In evaluation over real member sets, intended targets scored >= 0.90 and noise <= 0.85.
             const double SimilarityThreshold = 0.87;
 
             var scored = new List<(string Name, double Score, SuggestionKind Kind)>();
@@ -857,8 +853,7 @@ namespace Python.Runtime
                 var score = JaroWinklerSimilarity(name, candidate.Key);
                 if (score < SimilarityThreshold)
                 {
-                    // Containment matches score by how much of the longer name the fragment
-                    // covers, so they always rank below any Jaro-Winkler match.
+                    // Coverage scoring ranks containment matches below any similarity match.
                     score = IsMeaningfulContainment(name, candidate.Key)
                         ? (double)Math.Min(name.Length, candidate.Key.Length) / Math.Max(name.Length, candidate.Key.Length)
                         : 0;
@@ -910,11 +905,8 @@ namespace Python.Runtime
             };
         }
 
-        // A containment signal is only trustworthy when the contained fragment carries real
-        // information: at least 3 characters, and a candidate contained in the missed name
-        // must additionally cover at least half of it. Without the length gates every 1-2
-        // letter member (single-letter methods, greek-letter properties) is a substring of
-        // any long missed name and floods the suggestion list.
+        // Without the length gates every 1-2 letter member is a substring of any long
+        // missed name and floods the suggestion list.
         private static bool IsMeaningfulContainment(string name, string candidate)
         {
             const int MinFragmentLength = 3;
@@ -931,10 +923,7 @@ namespace Python.Runtime
         }
 
         /// <summary>
-        /// Case-insensitive Jaro-Winkler similarity in [0, 1]: the Jaro similarity (matching
-        /// characters within a sliding window, penalizing transpositions) boosted by up to
-        /// 0.1 per shared prefix character (capped at 4), so names that agree on their
-        /// leading characters rank higher than names with the same edit distance elsewhere.
+        /// Case-insensitive Jaro-Winkler similarity in [0, 1] (Jaro boosted by shared prefix).
         /// </summary>
         private static double JaroWinklerSimilarity(string a, string b)
         {

--- a/src/runtime/Types/ClassBase.cs
+++ b/src/runtime/Types/ClassBase.cs
@@ -49,7 +49,7 @@ namespace Python.Runtime
         // getattr(self, "_optional", None) on a .NET-derived object, or a mistyped enum value).
         // Memoize the fully-built " Did you mean: ...?" hint (empty when there is nothing to
         // suggest) per (type, missing-name) so repeats are a dictionary lookup instead of an
-        // O(members) reflection + Levenshtein scan on every miss.
+        // O(members) reflection + similarity scan on every miss.
         private static readonly ConcurrentDictionary<(Type Type, string Name), string> _suggestionCache = new();
 
         internal ClassBase(Type tp)
@@ -837,21 +837,36 @@ namespace Python.Runtime
         // Builds the " Did you mean: 'x', 'y'?" hint for a missing attribute, or an empty
         // string when no member is similar enough to suggest. The result is cached in
         // _suggestionCache, so this runs at most once per (type, missing-name).
+        //
+        // Similarity is Jaro-Winkler rather than a Levenshtein threshold: the prefix-favoring
+        // measure keeps suffix-extended real targets that an edit-distance cutoff rejects
+        // (BrokerageName.InteractiveBrokers -> INTERACTIVE_BROKERS_BROKERAGE is 11 edits away
+        // but 0.92 similar), while naturally rejecting the short-name noise edit distance
+        // admits ('cash' is within 2 edits of 'ASI'). Substring containment is kept as a
+        // fallback signal for fragment lookups Jaro-Winkler cannot see (its match window
+        // rules out 'cash' vs 'set_cash'), but only for fragments long enough to be
+        // meaningful, so 1-2 letter members no longer qualify for every long missed name.
         private static string ComputeSimilarMemberNames(Type type, string name)
         {
             const int MaxSuggestions = 5;
-            var threshold = Math.Max(2, name.Length / 3);
+            const double SimilarityThreshold = 0.87;
 
-            var scored = new List<(string Name, int Distance, SuggestionKind Kind)>();
+            var scored = new List<(string Name, double Score, SuggestionKind Kind)>();
             foreach (var candidate in GetCandidateMemberNames(type))
             {
-                var distance = LevenshteinDistance(name, candidate.Key);
-                var related = distance <= threshold
-                    || candidate.Key.IndexOf(name, StringComparison.OrdinalIgnoreCase) >= 0
-                    || name.IndexOf(candidate.Key, StringComparison.OrdinalIgnoreCase) >= 0;
-                if (related)
+                var score = JaroWinklerSimilarity(name, candidate.Key);
+                if (score < SimilarityThreshold)
                 {
-                    scored.Add((candidate.Key, distance, candidate.Value));
+                    // Containment matches score by how much of the longer name the fragment
+                    // covers, so they always rank below any Jaro-Winkler match.
+                    score = IsMeaningfulContainment(name, candidate.Key)
+                        ? (double)Math.Min(name.Length, candidate.Key.Length) / Math.Max(name.Length, candidate.Key.Length)
+                        : 0;
+                }
+
+                if (score > 0)
+                {
+                    scored.Add((candidate.Key, score, candidate.Value));
                 }
             }
 
@@ -861,7 +876,7 @@ namespace Python.Runtime
             }
 
             var ordered = scored
-                .OrderBy(t => t.Distance)
+                .OrderByDescending(t => t.Score)
                 .ThenBy(t => t.Name, StringComparer.OrdinalIgnoreCase)
                 .ToList();
 
@@ -895,30 +910,113 @@ namespace Python.Runtime
             };
         }
 
-        private static int LevenshteinDistance(string a, string b)
+        // A containment signal is only trustworthy when the contained fragment carries real
+        // information: at least 3 characters, and a candidate contained in the missed name
+        // must additionally cover at least half of it. Without the length gates every 1-2
+        // letter member (single-letter methods, greek-letter properties) is a substring of
+        // any long missed name and floods the suggestion list.
+        private static bool IsMeaningfulContainment(string name, string candidate)
         {
+            const int MinFragmentLength = 3;
+
+            if (name.Length >= MinFragmentLength
+                && candidate.IndexOf(name, StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return true;
+            }
+
+            return candidate.Length >= MinFragmentLength
+                && 2 * candidate.Length >= name.Length
+                && name.IndexOf(candidate, StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+
+        /// <summary>
+        /// Case-insensitive Jaro-Winkler similarity in [0, 1]: the Jaro similarity (matching
+        /// characters within a sliding window, penalizing transpositions) boosted by up to
+        /// 0.1 per shared prefix character (capped at 4), so names that agree on their
+        /// leading characters rank higher than names with the same edit distance elsewhere.
+        /// </summary>
+        private static double JaroWinklerSimilarity(string a, string b)
+        {
+            const double PrefixScale = 0.1;
+            const int MaxPrefixLength = 4;
+
             a = a.ToLowerInvariant();
             b = b.ToLowerInvariant();
+
+            var jaro = JaroSimilarity(a, b);
+
+            var prefix = 0;
+            var maxPrefix = Math.Min(MaxPrefixLength, Math.Min(a.Length, b.Length));
+            while (prefix < maxPrefix && a[prefix] == b[prefix])
+            {
+                prefix++;
+            }
+
+            return jaro + prefix * PrefixScale * (1 - jaro);
+        }
+
+        private static double JaroSimilarity(string a, string b)
+        {
+            if (a == b)
+            {
+                return 1;
+            }
+
             var n = a.Length;
             var m = b.Length;
-            if (n == 0) return m;
-            if (m == 0) return n;
-
-            var prev = new int[m + 1];
-            var curr = new int[m + 1];
-            for (var j = 0; j <= m; j++) prev[j] = j;
-
-            for (var i = 1; i <= n; i++)
+            if (n == 0 || m == 0)
             {
-                curr[0] = i;
-                for (var j = 1; j <= m; j++)
-                {
-                    var cost = a[i - 1] == b[j - 1] ? 0 : 1;
-                    curr[j] = Math.Min(Math.Min(curr[j - 1] + 1, prev[j] + 1), prev[j - 1] + cost);
-                }
-                (prev, curr) = (curr, prev);
+                return 0;
             }
-            return prev[m];
+
+            var window = Math.Max(0, Math.Max(n, m) / 2 - 1);
+            var aMatched = new bool[n];
+            var bMatched = new bool[m];
+
+            var matches = 0;
+            for (var i = 0; i < n; i++)
+            {
+                var lo = Math.Max(0, i - window);
+                var hi = Math.Min(m, i + window + 1);
+                for (var j = lo; j < hi; j++)
+                {
+                    if (!bMatched[j] && a[i] == b[j])
+                    {
+                        aMatched[i] = bMatched[j] = true;
+                        matches++;
+                        break;
+                    }
+                }
+            }
+
+            if (matches == 0)
+            {
+                return 0;
+            }
+
+            var transpositions = 0;
+            var k = 0;
+            for (var i = 0; i < n; i++)
+            {
+                if (!aMatched[i])
+                {
+                    continue;
+                }
+                while (!bMatched[k])
+                {
+                    k++;
+                }
+                if (a[i] != b[k])
+                {
+                    transpositions++;
+                }
+                k++;
+            }
+            transpositions /= 2;
+
+            return ((double)matches / n + (double)matches / m
+                + (double)(matches - transpositions) / matches) / 3;
         }
     }
 }

--- a/src/runtime/Types/ClassBase.cs
+++ b/src/runtime/Types/ClassBase.cs
@@ -850,7 +850,7 @@ namespace Python.Runtime
             var scored = new List<(string Name, double Score, SuggestionKind Kind)>();
             foreach (var candidate in GetCandidateMemberNames(type))
             {
-                var score = JaroWinklerSimilarity(name, candidate.Key);
+                var score = Util.JaroWinklerSimilarity(name, candidate.Key);
                 if (score < SimilarityThreshold)
                 {
                     // Coverage scoring ranks containment matches below any similarity match.
@@ -922,90 +922,5 @@ namespace Python.Runtime
                 && name.IndexOf(candidate, StringComparison.OrdinalIgnoreCase) >= 0;
         }
 
-        /// <summary>
-        /// Case-insensitive Jaro-Winkler similarity in [0, 1] (Jaro boosted by shared prefix).
-        /// </summary>
-        private static double JaroWinklerSimilarity(string a, string b)
-        {
-            const double PrefixScale = 0.1;
-            const int MaxPrefixLength = 4;
-
-            a = a.ToLowerInvariant();
-            b = b.ToLowerInvariant();
-
-            var jaro = JaroSimilarity(a, b);
-
-            var prefix = 0;
-            var maxPrefix = Math.Min(MaxPrefixLength, Math.Min(a.Length, b.Length));
-            while (prefix < maxPrefix && a[prefix] == b[prefix])
-            {
-                prefix++;
-            }
-
-            return jaro + prefix * PrefixScale * (1 - jaro);
-        }
-
-        private static double JaroSimilarity(string a, string b)
-        {
-            if (a == b)
-            {
-                return 1;
-            }
-
-            var n = a.Length;
-            var m = b.Length;
-            if (n == 0 || m == 0)
-            {
-                return 0;
-            }
-
-            var window = Math.Max(0, Math.Max(n, m) / 2 - 1);
-            var aMatched = new bool[n];
-            var bMatched = new bool[m];
-
-            var matches = 0;
-            for (var i = 0; i < n; i++)
-            {
-                var lo = Math.Max(0, i - window);
-                var hi = Math.Min(m, i + window + 1);
-                for (var j = lo; j < hi; j++)
-                {
-                    if (!bMatched[j] && a[i] == b[j])
-                    {
-                        aMatched[i] = bMatched[j] = true;
-                        matches++;
-                        break;
-                    }
-                }
-            }
-
-            if (matches == 0)
-            {
-                return 0;
-            }
-
-            var transpositions = 0;
-            var k = 0;
-            for (var i = 0; i < n; i++)
-            {
-                if (!aMatched[i])
-                {
-                    continue;
-                }
-                while (!bMatched[k])
-                {
-                    k++;
-                }
-                if (a[i] != b[k])
-                {
-                    transpositions++;
-                }
-                k++;
-            }
-            transpositions /= 2;
-
-            return ((double)matches / n + (double)matches / m
-                + (double)(matches - transpositions) / matches) / 3;
-        }
     }
 }

--- a/src/runtime/Util/Util.cs
+++ b/src/runtime/Util/Util.cs
@@ -336,5 +336,91 @@ namespace Python.Runtime
                     return false;
             }
         }
+
+        /// <summary>
+        /// Case-insensitive Jaro-Winkler similarity in [0, 1] (Jaro boosted by shared prefix).
+        /// </summary>
+        internal static double JaroWinklerSimilarity(string a, string b)
+        {
+            const double PrefixScale = 0.1;
+            const int MaxPrefixLength = 4;
+
+            a = a.ToLowerInvariant();
+            b = b.ToLowerInvariant();
+
+            var jaro = JaroSimilarity(a, b);
+
+            var prefix = 0;
+            var maxPrefix = Math.Min(MaxPrefixLength, Math.Min(a.Length, b.Length));
+            while (prefix < maxPrefix && a[prefix] == b[prefix])
+            {
+                prefix++;
+            }
+
+            return jaro + prefix * PrefixScale * (1 - jaro);
+        }
+
+        private static double JaroSimilarity(string a, string b)
+        {
+            if (a == b)
+            {
+                return 1;
+            }
+
+            var n = a.Length;
+            var m = b.Length;
+            if (n == 0 || m == 0)
+            {
+                return 0;
+            }
+
+            var window = Math.Max(0, Math.Max(n, m) / 2 - 1);
+            var aMatched = new bool[n];
+            var bMatched = new bool[m];
+
+            var matches = 0;
+            for (var i = 0; i < n; i++)
+            {
+                var lo = Math.Max(0, i - window);
+                var hi = Math.Min(m, i + window + 1);
+                for (var j = lo; j < hi; j++)
+                {
+                    if (!bMatched[j] && a[i] == b[j])
+                    {
+                        aMatched[i] = bMatched[j] = true;
+                        matches++;
+                        break;
+                    }
+                }
+            }
+
+            if (matches == 0)
+            {
+                return 0;
+            }
+
+            var transpositions = 0;
+            var k = 0;
+            for (var i = 0; i < n; i++)
+            {
+                if (!aMatched[i])
+                {
+                    continue;
+                }
+                while (!bMatched[k])
+                {
+                    k++;
+                }
+                if (a[i] != b[k])
+                {
+                    transpositions++;
+                }
+                k++;
+            }
+            transpositions /= 2;
+
+            return ((double)matches / n + (double)matches / m
+                + (double)(matches - transpositions) / matches) / 3;
+        }
     }
 }

--- a/src/testing/classtest.cs
+++ b/src/testing/classtest.cs
@@ -86,5 +86,33 @@ namespace Python.Test
         }
 
         public static int CalculationResult { get; set; }
+
+        // Short members: every one of these is a substring of a longer missed name like
+        // 'set_account_type', so suggestion tests can assert they are not offered as
+        // suggestions for it while a similarly-named longer member is.
+        public static int T()
+        {
+            return 0;
+        }
+
+        public static int CC()
+        {
+            return 0;
+        }
+
+        public static void SetAccountCurrency(string currency)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Supports missing-attribute suggestion tests for enum values whose real name extends
+    /// the guessed name with an extra suffix (a common miss on enum-like constant sets).
+    /// </summary>
+    public enum SuggestionEnum
+    {
+        InteractiveBrokersBrokerage,
+        InteractiveBrokersFix,
+        Binance,
     }
 }

--- a/src/testing/classtest.cs
+++ b/src/testing/classtest.cs
@@ -87,9 +87,8 @@ namespace Python.Test
 
         public static int CalculationResult { get; set; }
 
-        // Short members: every one of these is a substring of a longer missed name like
-        // 'set_account_type', so suggestion tests can assert they are not offered as
-        // suggestions for it while a similarly-named longer member is.
+        // Short members, all substrings of a longer miss like 'set_account_type', which
+        // must not suggest them.
         public static int T()
         {
             return 0;
@@ -106,8 +105,7 @@ namespace Python.Test
     }
 
     /// <summary>
-    /// Supports missing-attribute suggestion tests for enum values whose real name extends
-    /// the guessed name with an extra suffix (a common miss on enum-like constant sets).
+    /// Supports suggestion tests for enum members that extend the guessed name with a suffix.
     /// </summary>
     public enum SuggestionEnum
     {

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -211,6 +211,43 @@ def test_missing_property_suggests_data_only():
     assert "'calculation_results'" not in hint
 
 
+def _suggestions(message):
+    """Extract the quoted member names from a "Did you mean" hint."""
+    import re
+    return re.findall(r"'([^']+)'", message.split("Did you mean")[1])
+
+
+def test_missing_attribute_does_not_suggest_short_members():
+    """A long missed name must not collect 1-2 letter members via substring containment.
+
+    Types like QCAlgorithm expose many 1-2 letter members (indicator shortcuts, greek
+    letters); every one of them is a substring of a long missed name, so they used to
+    flood the hint (e.g. 'set_account_type' -> "Did you mean: 'cc', 'co', 'a', 'c',
+    't'?") while the member the user most likely meant was not within the edit-distance
+    threshold and did not appear at all.
+    """
+    from Python.Test import SuggestionTest
+
+    with pytest.raises(AttributeError) as exc_info:
+        _ = SuggestionTest.set_account_type
+
+    message = str(exc_info.value)
+    assert "Did you mean" in message
+    suggested = _suggestions(message)
+    assert "set_account_currency" in suggested
+    assert all(len(s) > 2 for s in suggested)
+
+
+def test_missing_attribute_fragment_suggests_containing_member():
+    """Typing a meaningful fragment of a member name still suggests that member."""
+    from Python.Test import SuggestionTest
+
+    with pytest.raises(AttributeError) as exc_info:
+        _ = SuggestionTest.currency
+
+    assert "set_account_currency" in _suggestions(str(exc_info.value))
+
+
 def test_missing_static_member_no_similar():
     """A static member with no similar name keeps the standard message (no hint)."""
     from System import Math

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -220,11 +220,8 @@ def _suggestions(message):
 def test_missing_attribute_does_not_suggest_short_members():
     """A long missed name must not collect 1-2 letter members via substring containment.
 
-    Types like QCAlgorithm expose many 1-2 letter members (indicator shortcuts, greek
-    letters); every one of them is a substring of a long missed name, so they used to
-    flood the hint (e.g. 'set_account_type' -> "Did you mean: 'cc', 'co', 'a', 'c',
-    't'?") while the member the user most likely meant was not within the edit-distance
-    threshold and did not appear at all.
+    Every short member is a substring of a long miss, so hints used to read
+    "Did you mean: 'cc', 'co', 'a', 'c', 't'?" while the intended member was absent.
     """
     from Python.Test import SuggestionTest
 

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -68,6 +68,29 @@ def test_missing_enum_member_hasattr_still_false():
     assert not hasattr(DayOfWeek, "Sundey")
 
 
+def test_missing_enum_member_suffix_extended_name_suggested():
+    """A guessed name that the real member extends with a suffix must be suggested.
+
+    Enum-like constant sets often have members that extend the natural guess (e.g.
+    BrokerageName.INTERACTIVE_BROKERS_BROKERAGE for a guessed INTERACTIVE_BROKERS);
+    such members are many edits away, so a pure edit-distance threshold missed them.
+    Both the PascalCase and the UPPER_SNAKE guess must surface every extension.
+    """
+    import re
+    from Python.Test import SuggestionEnum
+
+    for miss in ("InteractiveBrokers", "INTERACTIVE_BROKERS"):
+        with pytest.raises(AttributeError) as exc_info:
+            getattr(SuggestionEnum, miss)
+
+        message = str(exc_info.value)
+        assert "Did you mean" in message
+        suggested = re.findall(r"'([^']+)'", message.split("Did you mean")[1])
+        assert "INTERACTIVE_BROKERS_BROKERAGE" in suggested
+        assert "INTERACTIVE_BROKERS_FIX" in suggested
+        assert "BINANCE" not in suggested
+
+
 def test_byte_enum():
     """Test byte enum."""
     assert Test.ByteEnum.Zero == Test.ByteEnum(0)

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -69,13 +69,8 @@ def test_missing_enum_member_hasattr_still_false():
 
 
 def test_missing_enum_member_suffix_extended_name_suggested():
-    """A guessed name that the real member extends with a suffix must be suggested.
-
-    Enum-like constant sets often have members that extend the natural guess (e.g.
-    BrokerageName.INTERACTIVE_BROKERS_BROKERAGE for a guessed INTERACTIVE_BROKERS);
-    such members are many edits away, so a pure edit-distance threshold missed them.
-    Both the PascalCase and the UPPER_SNAKE guess must surface every extension.
-    """
+    """A guessed name that the real member extends with a suffix must be suggested,
+    from both the PascalCase and the UPPER_SNAKE spelling of the guess."""
     import re
     from Python.Test import SuggestionEnum
 


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Improves the quality of the "Did you mean" hints on missing-attribute errors, fixing two defects in how similar member names are selected:

1. **1–2 letter members flooded the hint for long missed names.** The substring-containment test admitted any member that appears inside the missed name, and types like `QCAlgorithm` expose many 1–2 letter members (indicator shortcuts, greek letters), every one of which is a substring of a long name:

   ```
   'QCAlgorithm' object has no attribute 'set_account_type' Did you mean: 'cc', 'co', 'a', 'c', 't'?
   ```

   Containment now only counts for fragments of at least 3 characters, and a candidate contained in the missed name must additionally cover at least half of it.

2. **Suffix-extended members were never suggested.** The Levenshtein threshold `max(2, len/3)` rejected members whose real name extends the guess with a suffix, so the member the user most likely meant could be missing from its own hint:

   ```
   type object 'BrokerageName' has no attribute 'InteractiveBrokers' Did you mean: 'INTERACTIVE_BROKERS_FIX'?
   ```

   (`INTERACTIVE_BROKERS_BROKERAGE` — 11 edits away — was not suggested.) The edit-distance threshold is replaced with Jaro-Winkler similarity (threshold 0.87), a prefix-favoring measure that keeps suffix extensions and, as a bonus, rejects the junk matches short names produced under the distance cutoff (e.g. `PII` no longer suggests `'min', 'pow', 'sin'` alongside `'PI'`).

Both fleet-reported cases now produce the intended hints against real Lean types:

```
'QCAlgorithm' object has no attribute 'set_account_type' Did you mean: 'set_account_currency'?
type object 'BrokerageName' has no attribute 'InteractiveBrokers' Did you mean: 'INTERACTIVE_BROKERS_FIX', 'INTERACTIVE_BROKERS_BROKERAGE'?
```

**Algorithm selection.** Two candidate replacements were evaluated over real member pools (590 `QCAlgorithm` members, `BrokerageName`, `System.String`, `System.Math`, `DayOfWeek`, plus the existing test fixtures): a token-based clause (split on `_`/camel humps, relate on shared tokens, keep Levenshtein for typos) and Jaro-Winkler. Both pass all 13 graded cases; Jaro-Winkler was chosen because it *replaces* the edit-distance clause instead of augmenting it, so it also fixes the short-name junk the token variant inherits, with less code:

| Missed name | Before | Token-based | Jaro-Winkler (chosen) |
|---|---|---|---|
| `QCAlgorithm.set_account_type` | `cc, co, a, c, t` | `set_account_currency` | `set_account_currency` |
| `BrokerageName.InteractiveBrokers` | `INTERACTIVE_BROKERS_FIX` | both IB members | both IB members |
| `BrokerageName.INTERACTIVE_BROKERS` | both IB members | both | both |
| `String.lenght` | `length` | `length` | `length` |
| `Math.PII` | `PI, min, pow, sin` | `PI, min, pow, sin` | `PI` |
| `String.Empy` | `EMPTY, copy` | `EMPTY, copy` | `EMPTY` |
| `QCAlgorithm.cash` | `ASI, asi, CKS, cks, CRSI` | `ASI, asi, CKS, cks, CRSI` | `set_cash` |
| `QCAlgorithm.market_ordr` | `market_order, AR, ar, A, a` | `market_order` | `market_order, market_on_open_order, …` |

Threshold margins at 0.87: all intended targets score ≥ 0.90; the trimmed noise sits ≤ 0.851. Substring containment is kept (gated) as a fallback for fragment lookups Jaro-Winkler's match window cannot see (`cash` → `set_cash`), scored by coverage so such matches always rank below similarity matches. The per-type candidate cache, per-(type, name) hint memoization, kind filtering and the 5-suggestion cap are unchanged.

### Does this close any currently open issues?

No open issue in this repo; addresses the enum/member did-you-mean defects from QuantConnect/Agents#305 (improvement 1).

### Any other comments?

Tests: `py -3.11 -m pytest --runtime netcore tests` → 459 passed, 1 failed (`test_module.py::test_explicit_assembly_load`, pre-existing environmental failure, reproduced on unmodified master), 23 skipped. `dotnet test src/embed_tests/Python.EmbeddingTest.csproj -c Release --filter "FullyQualifiedName!~SetPythonPath"` → 971 passed, 0 failed.

Note: #144 moves `LevenshteinDistance` into the same `Util.cs` this PR adds the Jaro-Winkler helpers to (and this PR removes that method's ClassBase copy), so whichever lands second has a trivial both-append merge in `Util.cs` and a deletion conflict in `ClassBase.cs`.

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Ensure you have signed the [.NET Foundation CLA](https://cla.dotnetfoundation.org/pythonnet/pythonnet)
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)

